### PR TITLE
Removed unused import to fix build error

### DIFF
--- a/src/routes/Main/ApiDetail/Options.tsx
+++ b/src/routes/Main/ApiDetail/Options.tsx
@@ -5,7 +5,7 @@
 
 import { FC, useEffect, useState } from "react";
 import { Body1, Body1Strong, Button, Caption1, Link, MessageBar, MessageBarBody } from "@fluentui/react-components";
-import { ArrowDownloadRegular, Document20Regular, Play16Filled } from "@fluentui/react-icons";
+import { ArrowDownloadRegular, Document20Regular } from "@fluentui/react-icons";
 
 import VsCodeLogo from "../../../components/logos/VsCodeLogo";
 import { Api } from "../../../contracts/api";


### PR DESCRIPTION
Unused Play16Filled import throws error during build as part of the SWA CI/CD workflow.

![image](https://github.com/Azure/APICenter-Portal-Starter/assets/40116776/48d5997c-7c8e-46c4-906c-b7728534991a)
