### PR TITLE
Added the scopingFilter setting to allow pre-filtering APIs based on a custom metadata property

### DIFF
--- a/public/config.example
+++ b/public/config.example
@@ -5,6 +5,7 @@
       "clientId": "<client ID>",
       "tenantId": "<tenant ID>",
       "scopes": ["https://azure-apicenter.net/user_impersonation"],
-      "authority": "https://login.microsoftonline.com/"
-  }
+      "authority": "https://login.microsoftonline.com/",
+  },
+  "scopingFilter": ""
 }

--- a/src/contracts/settings.ts
+++ b/src/contracts/settings.ts
@@ -23,4 +23,10 @@ export interface Settings {
      * The authentication settings.
      */
     authentication: MsalSettings;
+
+    /**
+     * The scoping filter. If provided, only APIs with the specified metadata properties will be shown.
+     */
+    scopingFilter: string;
+
 }

--- a/src/routes/Main/ApisList/index.tsx
+++ b/src/routes/Main/ApisList/index.tsx
@@ -114,10 +114,10 @@ const ApisList = () => {
             if (filterQuery.length > 0) {
                 filterQuery = "$filter=" + filterQuery;
                 if (config.scopingFilter.length > 0) {
-                    filterQuery += " and " + config.scopingFilter;    
+                    filterQuery += " and (" + config.scopingFilter + ")";    
                 }    
             } else if (config.scopingFilter.length > 0) {
-                filterQuery = "$filter=" + config.scopingFilter;    
+                filterQuery = "$filter=(" + config.scopingFilter + ")";    
             }           
         }
 


### PR DESCRIPTION
This addresses the necessity of having multiple API Center Portals for different API contexts or scopes. For instance, business unit X could have a dedicated API Center Portal that exclusively displays APIs associated with their business unit, through a custom property that links APIs with that business unit.
By default the scopingFilter setting should be empty to display all the APIs. To set a scope, set the scoping filter with a query such as "customProperties/businessUnit eq 'X'".
