### PR TITLE
Fixed definition selector. Added promise caching for specification requests.

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -6,6 +6,7 @@
 export const TableColumns = [
     { label: "Name", value: "name" },
     { label: "Type", value: "kind" },
+    { label: "Lifecycle", value: "lifecycleStage" },
     { label: "Description", value: "description" },
     { label: "Last updated", value: "lastUpdated" },
     // {label: "Created by", value: "createdBy"},

--- a/src/routes/Main/ApiDetail/Options.tsx
+++ b/src/routes/Main/ApiDetail/Options.tsx
@@ -16,7 +16,7 @@ import VsCodeLogo from "../../../components/logos/VsCodeLogo";
 
 import css from "./index.module.scss";
 
-const Options: FC<{ api: Api; version?: string; definition?: string, environment?: Environment }> = ({ api, version, definition, environment }) => {
+const Options: FC<{ api: Api; version?: string; definition?: string, environment?: Environment }> = ({ api, version: versionName, definition: definitionName, environment }) => {
     const apiService = useApiService();    
     const navigate = useNavigate();
     const [schemaUrl, setSchemaUrl] = useState("");
@@ -28,9 +28,9 @@ const Options: FC<{ api: Api; version?: string; definition?: string, environment
     }, [schemaUrl]);
     
     const getSpecificationLink = async () => {
-        if (!version || !definition) return;
+        if (!versionName || !definitionName) return;
 
-        const downloadUrl = await apiService.getSpecificationLink(api.name, version, definition);
+        const downloadUrl = await apiService.getSpecificationLink(api.name, versionName, definitionName);
 
         if (!downloadUrl) {
             return;
@@ -41,7 +41,7 @@ const Options: FC<{ api: Api; version?: string; definition?: string, environment
 
     return (
         <div className={css.options}>
-            {!version || !definition ? (
+            {!versionName || !definitionName ? (
                 <MessageBar>
                     <MessageBarBody>There are no available options for this API.</MessageBarBody>
                 </MessageBar>
@@ -59,7 +59,7 @@ const Options: FC<{ api: Api; version?: string; definition?: string, environment
                                         <Link href={schemaUrl} className={css.link}>
                                             <Caption1>Download</Caption1> <ArrowDownloadRegular />
                                         </Link>
-                                        <Link className={css.link} onClick={() => navigate(`/swagger/${api.name}/${version}/${definition}`)}>
+                                        <Link className={css.link} onClick={() => navigate(`/swagger/${api.name}/${versionName}/${definitionName}`)}>
                                             <Caption1>View documentation</Caption1>
                                         </Link>
                                     </>

--- a/src/routes/Main/ApiDetail/index.tsx
+++ b/src/routes/Main/ApiDetail/index.tsx
@@ -53,7 +53,7 @@ const ApiDetail = () => {
     useEffect(() => {
         setIsLoading(true);
         fetchApi();
-    }, [id, isAuthenticated]);
+    }, [id]);
 
     useEffect(() => {
         setIsLoading(true);
@@ -64,7 +64,14 @@ const ApiDetail = () => {
 
     useEffect(() => {
         setIsLoading(true);
-        if (selectedDeployment.length > 0) {
+        if (isAuthenticated && selectedDefinition.length > 0) {
+            fetchDeployments();
+        }
+    }, [selectedDefinition, isAuthenticated]);
+
+    useEffect(() => {
+        setIsLoading(true);
+        if (isAuthenticated && selectedDeployment.length > 0) {
             fetchEnvironment();
         }
     }, [selectedDeployment, isAuthenticated]);
@@ -74,6 +81,8 @@ const ApiDetail = () => {
     const fetchApi = async () => {
         const isAuthenticatedResponse = await authService.isAuthenticated();
         setIsAuthenticated(isAuthenticatedResponse);
+
+        if (!isAuthenticatedResponse) return;
 
         const api = await apiService.getApi(id);
         setApi(api);
@@ -85,13 +94,7 @@ const ApiDetail = () => {
             setSelectedVersion([versions.value[0].name]);
             setSelectedVersionLabel(versions.value[0].title);
         }
-
-        const deployments = await apiService.getDeployments(id);
-        setDeployments(deployments.value);
-        if (deployments.value.length > 0) {
-            setSelectedDeployment([deployments.value[0].name]);
-            setSelectedDeploymentLabel(deployments.value[0].title);
-        }
+        setIsLoading(false);
     };
 
     const fetchDefinitions = async () => {
@@ -104,6 +107,17 @@ const ApiDetail = () => {
         }
         setIsLoading(false);
     };
+
+    const fetchDeployments = async () => {
+        const deployments = await apiService.getDeployments(id);
+        setDeployments(deployments.value);
+
+        if (deployments.value.length > 0) {
+            setSelectedDeployment([deployments.value[0].name]);
+            setSelectedDeploymentLabel(deployments.value[0].title);
+        }
+        setIsLoading(false);
+    }
 
     const fetchEnvironment = async () => {
         const environmentId = deployments?.find(d => d.name === selectedDeployment[0])?.environmentId;

--- a/src/routes/Main/ApisList/ApisTable/index.module.scss
+++ b/src/routes/Main/ApisList/ApisTable/index.module.scss
@@ -13,4 +13,8 @@
 			text-decoration: underline;
 		}
 	}
+
+	.capitalize {
+		text-transform: capitalize;
+	}
 }

--- a/src/routes/Main/ApisList/ApisTable/index.tsx
+++ b/src/routes/Main/ApisList/ApisTable/index.tsx
@@ -42,13 +42,13 @@ const ApisTable: FC<{ apis: Api[] | null }> = ({ apis }) => {
                                 </Link>
                             </TableCell>
                             <TableCell>{api.kind.toUpperCase()}</TableCell>
+                            <TableCell className={css.capitalize}>{api.lifecycleStage}</TableCell>
                             <TableCell>
                                 <TableCellLayout truncate title={api.description}>
                                     {api.description}
                                 </TableCellLayout>
                             </TableCell>
-                            <TableCell>{new Date(api.lastUpdated || Date.now()).toLocaleDateString()}</TableCell>                            {/* <TableCell>TODO</TableCell> */}
-                            {/* <TableCell>TODO</TableCell> */}
+                            <TableCell>{new Date(api.lastUpdated || Date.now()).toLocaleDateString()}</TableCell>
                         </TableRow>
                     ))}
                 </TableBody>

--- a/src/routes/Main/Swagger/index.tsx
+++ b/src/routes/Main/Swagger/index.tsx
@@ -40,7 +40,6 @@ const Swagger = () => {
         );
 
         const specName = definition.specification?.name ?? "rest";
-        console.log(specName);
         setSpecType(specName);
 
         const downloadUrl = await apiService.getSpecificationLink(


### PR DESCRIPTION
**Problem**: The definition selector on the Details page was not functioning correctly, not allowing users to select an API definition for viewing and downloading.