### PR TITLE
Take into consideration vite public base path

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -30,7 +30,7 @@ const router = createBrowserRouter([
             }
         ],
     },
-]);
+], { basename: import.meta.env.BASE_URL });
 
 const Router = () => <RouterProvider router={router} />;
 

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -13,7 +13,7 @@ export class ConfigService implements IConfigService {
     private settingsPromise?: Promise<Settings>;
 
     private async loadFromFile(): Promise<Settings> {
-        const response = await fetch("/config.json");
+        const response = await fetch(`${import.meta.env.BASE_URL == "/" ? "" : import.meta.env.BASE_URL}/config.json`);
         const dataJson = await response.json();
 
         return dataJson;


### PR DESCRIPTION
Take into consideration the vite's [public base path](https://vite.dev/guide/build#public-base-path) for when the router is defined and when we get the `config.json` .