### PR TITLE
Add Skill Assessment support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "react-markdown": "9.0.1",
                 "react-router-dom": "6.22.3",
                 "react-timeago": "8.0.0",
+                "recharts": "^3.8.1",
                 "recoil": "0.7.7",
                 "recoil-nexus": "0.5.1",
                 "rehype-raw": "7.0.0",
@@ -2722,6 +2723,42 @@
                 "url": "https://opencollective.com/unts"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+            "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@reduxjs/toolkit/node_modules/immer": {
+            "version": "11.1.4",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+            "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/@remix-run/router": {
             "version": "1.15.3",
             "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
@@ -3069,6 +3106,18 @@
             "integrity": "sha512-sBSO19KzdrJCM3gdx6eIxV8M9Gxfgg6iDQmH5TIAGaUu+X9VDdsINXJOnoiZ1Kx3TrHdH4bt5UVglkjsEGBcvw==",
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+            "license": "MIT"
+        },
         "node_modules/@storybook/csf": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
@@ -3133,6 +3182,69 @@
             "peerDependencies": {
                 "react": "^18 || ^19"
             }
+        },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
         },
         "node_modules/@types/debug": {
             "version": "4.1.13",
@@ -3245,6 +3357,12 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4438,6 +4556,15 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4603,6 +4730,127 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4680,6 +4928,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
@@ -5035,6 +5289,16 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.45.1",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+            "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
         },
         "node_modules/es5-ext": {
             "version": "0.10.64",
@@ -5604,6 +5868,12 @@
                 "d": "1",
                 "es5-ext": "~0.10.14"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/eventsource": {
             "version": "3.0.6",
@@ -6502,6 +6772,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/immutable": {
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
@@ -6568,6 +6848,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-alphabetical": {
@@ -9142,7 +9431,6 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/react-markdown": {
@@ -9169,6 +9457,29 @@
             "peerDependencies": {
                 "@types/react": ">=18",
                 "react": ">=18"
+            }
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-router": {
@@ -9229,6 +9540,36 @@
                 "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/recharts": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+            "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/recoil": {
             "version": "0.7.7",
             "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
@@ -9260,6 +9601,21 @@
                 "react-dom": ">=16.8.0",
                 "recoil": ">=0.2.0",
                 "typescript": ">=4.1.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -9523,6 +9879,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "license": "MIT"
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
             "license": "MIT"
         },
         "node_modules/resolve": {
@@ -11010,6 +11372,12 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11491,6 +11859,28 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "@azure/msal-browser": "3.13.0",
         "@fluentui/react-components": "9.56.8",
-        "api-docs-ui": "1.0.29",
         "@tanstack/react-query": "5.85.5",
         "@vitejs/plugin-basic-ssl": "1.2.0",
+        "api-docs-ui": "1.0.29",
         "classnames": "2.5.1",
         "client-oauth2": "4.3.3",
         "eventsource": "3.0.6",
@@ -29,6 +29,7 @@
         "react-markdown": "9.0.1",
         "react-router-dom": "6.22.3",
         "react-timeago": "8.0.0",
+        "recharts": "^3.8.1",
         "recoil": "0.7.7",
         "recoil-nexus": "0.5.1",
         "rehype-raw": "7.0.0",

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -15,4 +15,5 @@ export enum QueryKeys {
   MetadataSchemas = 'MetadataSchemas',
   Plugin = 'Plugin',
   LanguageModel = 'LanguageModel',
+  SkillEvaluationResult = 'SkillEvaluationResult',
 }

--- a/src/experiences/SkillEvaluation/EvalAssertionList.tsx
+++ b/src/experiences/SkillEvaluation/EvalAssertionList.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { Badge, Button } from '@fluentui/react-components';
+import {
+  CheckmarkCircle20Regular,
+  DismissCircle20Regular,
+  ChevronDown20Regular,
+  ChevronUp20Regular,
+} from '@fluentui/react-icons';
+import { EvalAssertion, EvalTierResult } from '@/types/skillEvaluation';
+import styles from './SkillEvaluation.module.scss';
+
+/** Static descriptions for known L0 / L1 assertion names. */
+const ASSERTION_DESCRIPTIONS: Record<string, string> = {
+  // L0 — Structural checks
+  'frontmatter-present': 'Verifies that the SKILL.md file begins with a valid YAML frontmatter block.',
+  'has-name': 'Checks that the frontmatter declares a skill name.',
+  'has-description': 'Checks that the frontmatter includes a description field.',
+  'body-not-empty': 'Ensures the SKILL.md body contains meaningful content beyond the frontmatter.',
+
+  // L1 — Schema / pattern validation
+  'has-instructions-section': 'Verifies that the skill file contains an explicit instructions section.',
+  'has-examples-section': 'Checks for an examples section demonstrating usage patterns.',
+  'has-error-handling-section': 'Checks for a section describing error handling and edge cases.',
+};
+
+interface EvalAssertionListProps {
+  title: string;
+  tier: EvalTierResult<EvalAssertion>;
+}
+
+export const EvalAssertionList: React.FC<EvalAssertionListProps> = ({ title, tier }) => {
+  const [expanded, setExpanded] = useState(false);
+  const assertions = tier.assertions ?? [];
+
+  return (
+    <div className={styles.assertionSection}>
+      <div className={styles.assertionHeader}>
+        <h4 className={styles.assertionTitle}>{title}</h4>
+        <Badge
+          appearance="tint"
+          color={tier.status === 'pass' ? 'success' : 'danger'}
+          shape="circular"
+        >
+          {tier.passed}/{tier.total} passed
+        </Badge>
+        {assertions.length > 0 && (
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={expanded ? <ChevronUp20Regular /> : <ChevronDown20Regular />}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? 'Hide' : 'Show'} details
+          </Button>
+        )}
+      </div>
+
+      {expanded && assertions.length > 0 && (
+        <ul className={styles.assertionList}>
+          {assertions.map((a) => {
+            const description = ASSERTION_DESCRIPTIONS[a.name];
+            return (
+              <li key={a.name} className={styles.assertionItem}>
+                {a.status === 'pass' ? (
+                  <CheckmarkCircle20Regular className={styles.assertionIconPass} />
+                ) : (
+                  <DismissCircle20Regular className={styles.assertionIconFail} />
+                )}
+                <div>
+                  <span className={styles.assertionName}>{a.name}</span>
+                  {a.message && <span className={styles.assertionMessage}> — {a.message}</span>}
+                  {description && <p className={styles.assertionDescription}>{description}</p>}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(EvalAssertionList);

--- a/src/experiences/SkillEvaluation/EvalRadarChart.tsx
+++ b/src/experiences/SkillEvaluation/EvalRadarChart.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo } from 'react';
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Dot,
+} from 'recharts';
+import { EvalJudgeScore } from '@/types/skillEvaluation';
+
+interface EvalRadarChartProps {
+  scores: EvalJudgeScore[];
+}
+
+function formatLabel(name: string): string {
+  return name
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Wraps long axis labels into multiple lines. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderMultiLineLabel(props: any) {
+  const { payload, x, y, cx, cy } = props;
+  const words = payload.value.split(' ');
+  const lines: string[] = [];
+  let current = '';
+  for (const w of words) {
+    if (current && (current + ' ' + w).length > 14) {
+      lines.push(current);
+      current = w;
+    } else {
+      current = current ? current + ' ' + w : w;
+    }
+  }
+  if (current) lines.push(current);
+
+  const anchor = x > cx ? 'start' : x < cx ? 'end' : 'middle';
+  const dy = y > cy ? 4 : y < cy ? -4 : 0;
+
+  return (
+    <text x={x} y={y + dy} textAnchor={anchor} fontSize={11} fill="var(--colorNeutralForeground3)">
+      {lines.map((line, i) => (
+        <tspan key={i} x={x} dy={i === 0 ? 0 : 14}>{line}</tspan>
+      ))}
+    </text>
+  );
+}
+
+function dotColor(score: number, maxScore: number): string {
+  const ratio = maxScore > 0 ? score / maxScore : 0;
+  if (ratio >= 0.8) return '#107C10'; // green
+  if (ratio >= 0.6) return '#CA5010'; // orange
+  return '#D13438';                   // red
+}
+
+/** Custom dot with score label. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderDot(props: any) {
+  const { cx, cy, index, payload } = props;
+  const color = dotColor(payload.value, payload.fullMark);
+  return (
+    <g key={index}>
+      <Dot cx={cx} cy={cy} r={5} fill={color} stroke="#fff" strokeWidth={1.5} />
+      <text x={cx} y={cy - 10} textAnchor="middle" fontSize={10} fontWeight={600} fill={color}>
+        {payload.value}
+      </text>
+    </g>
+  );
+}
+
+/** Radar chart visualising quality-assessment criteria. Needs ≥ 3 scores. */
+export const EvalRadarChart: React.FC<EvalRadarChartProps> = ({ scores }) => {
+  const data = useMemo(
+    () =>
+      scores.map((s) => ({
+        name: formatLabel(s.name),
+        value: s.score,
+        fullMark: s.maxScore,
+      })),
+    [scores],
+  );
+
+  if (data.length < 3) return null;
+
+  const maxScore = Math.max(...scores.map((s) => s.maxScore), 5);
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <RadarChart data={data} cx="50%" cy="50%" outerRadius="65%">
+        <PolarGrid stroke="var(--colorNeutralStroke2)" />
+        <PolarAngleAxis
+          dataKey="name"
+          tick={renderMultiLineLabel}
+        />
+        <PolarRadiusAxis domain={[0, maxScore]} tick={false} axisLine={false} />
+        <Radar
+          dataKey="value"
+          stroke="var(--colorBrandForeground1)"
+          fill="var(--colorBrandForeground1)"
+          fillOpacity={0.15}
+          strokeWidth={2}
+          dot={renderDot}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default React.memo(EvalRadarChart);

--- a/src/experiences/SkillEvaluation/EvalScoreBadge.tsx
+++ b/src/experiences/SkillEvaluation/EvalScoreBadge.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Badge } from '@fluentui/react-components';
+import { SkillEvaluationResult } from '@/types/skillEvaluation';
+import styles from './SkillEvaluation.module.scss';
+
+interface EvalScoreBadgeProps {
+  evalResult?: SkillEvaluationResult;
+}
+
+type BadgeColor = 'success' | 'warning' | 'danger';
+
+function scoreBadgeColor(ratio: number): BadgeColor {
+  if (ratio >= 0.8) return 'success';
+  if (ratio >= 0.6) return 'warning';
+  return 'danger';
+}
+
+/** Compact score pill for the header metadata area. */
+export const EvalScoreBadge: React.FC<EvalScoreBadgeProps> = ({ evalResult }) => {
+  if (!evalResult || evalResult.maxScore <= 0) return null;
+
+  const ratio = evalResult.overallScore / evalResult.maxScore;
+  const normalized = ratio * 5;
+  const display = normalized.toFixed(1);
+  const color = scoreBadgeColor(ratio);
+
+  return (
+    <span className={styles.scoreBadge}>
+      <Badge
+        appearance="filled"
+        color={color}
+        shape="circular"
+        className={styles.scoreBadgePill}
+      >
+        {display} <span className={styles.scoreBadgeMax}>/5</span>
+      </Badge>
+      <span className={styles.scoreBadgeLabel}>AI Quality Score</span>
+    </span>
+  );
+};
+
+export default React.memo(EvalScoreBadge);

--- a/src/experiences/SkillEvaluation/EvalScoreBar.tsx
+++ b/src/experiences/SkillEvaluation/EvalScoreBar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { EvalJudgeScore } from '@/types/skillEvaluation';
+import styles from './SkillEvaluation.module.scss';
+
+interface EvalScoreBarProps {
+  score: EvalJudgeScore;
+}
+
+function scoreColor(score: number, maxScore: number): string {
+  const ratio = maxScore > 0 ? score / maxScore : 0;
+  if (ratio >= 0.8) return 'var(--colorPaletteGreenBackground3)';
+  if (ratio >= 0.6) return 'var(--colorPaletteYellowBackground3)';
+  return 'var(--colorPaletteRedBackground3)';
+}
+
+function formatLabel(name: string): string {
+  return name
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export const EvalScoreBar: React.FC<EvalScoreBarProps> = ({ score }) => {
+  const pct = score.maxScore > 0 ? (score.score / score.maxScore) * 100 : 0;
+  const color = scoreColor(score.score, score.maxScore);
+
+  return (
+    <div className={styles.scoreBarItem}>
+      <div className={styles.scoreBarHeader}>
+        <span className={styles.scoreBarLabel}>{formatLabel(score.name)}</span>
+        <span className={styles.scoreBarValue}>{score.score.toFixed(1)}</span>
+      </div>
+      <div className={styles.scoreBarTrack}>
+        <div
+          className={styles.scoreBarFill}
+          style={{ width: `${pct}%`, backgroundColor: color }}
+        />
+      </div>
+      {score.reasoning && (
+        <p className={styles.scoreBarReasoning}>{score.reasoning}</p>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(EvalScoreBar);

--- a/src/experiences/SkillEvaluation/SkillEvaluation.module.scss
+++ b/src/experiences/SkillEvaluation/SkillEvaluation.module.scss
@@ -1,0 +1,205 @@
+/* ── Score badge (header metadata area) ── */
+
+.scoreBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scoreBadgePill {
+  font-weight: 600;
+}
+
+.scoreBadgeMax {
+  font-weight: 400;
+  opacity: 0.8;
+}
+
+.scoreBadgeLabel {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--colorNeutralForeground1);
+}
+
+/* ── Evaluation details (tab content) ── */
+
+.evalDetails {
+  max-width: 100%;
+}
+
+.evalHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.evalHeaderBadge {
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 4px 12px;
+}
+
+.evalHeaderTitle {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.evalUpdated {
+  margin: 0 0 24px;
+  color: var(--colorNeutralForeground3);
+  font-size: 0.8125rem;
+}
+
+.evalSection {
+  margin-bottom: 32px;
+}
+
+.evalSectionTitle {
+  margin: 0 0 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--colorNeutralForeground2);
+}
+
+.evalContentLayout {
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
+/* ── Score bar ── */
+
+.scoreBarList {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  flex: 1;
+  min-width: 0;
+}
+
+.radarContainer {
+  flex: 0 0 320px;
+  min-height: 280px;
+
+  @media (max-width: 768px) {
+    flex: none;
+    width: 100%;
+  }
+}
+
+.scoreBarItem {
+  padding-left: 0;
+  border-left: none;
+}
+
+.scoreBarHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.scoreBarLabel {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.scoreBarValue {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  color: var(--colorNeutralForeground2);
+}
+
+.scoreBarTrack {
+  height: 8px;
+  border-radius: 4px;
+  background-color: var(--colorNeutralBackground3);
+  overflow: hidden;
+}
+
+.scoreBarFill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.scoreBarReasoning {
+  margin: 8px 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--colorNeutralForeground3);
+}
+
+/* ── Assertion list ── */
+
+.assertionSection {
+  margin-top: 32px;
+  margin-bottom: 24px;
+}
+
+.assertionHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.assertionTitle {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--colorNeutralForeground2);
+}
+
+.assertionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.assertionItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.assertionIconPass {
+  color: var(--colorPaletteGreenForeground1);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.assertionIconFail {
+  color: var(--colorPaletteRedForeground1);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.assertionName {
+  font-weight: 600;
+}
+
+.assertionMessage {
+  color: var(--colorNeutralForeground3);
+}
+
+.assertionDescription {
+  margin: 4px 0 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--colorNeutralForeground4);
+}

--- a/src/experiences/SkillEvaluation/SkillEvaluationDetails.tsx
+++ b/src/experiences/SkillEvaluation/SkillEvaluationDetails.tsx
@@ -16,7 +16,7 @@ export const SkillEvaluationDetails: React.FC<SkillEvaluationDetailsProps> = ({
   isLoading,
 }) => {
   if (isLoading) {
-    return <Spinner size="small" label="Loading evaluation results..." labelPosition="below" />;
+    return <Spinner size="small" label="Loading assessment results..." labelPosition="below" />;
   }
 
   if (!evalResult) return null;
@@ -58,14 +58,14 @@ export const SkillEvaluationDetails: React.FC<SkillEvaluationDetailsProps> = ({
 
       {evalResult.updatedOn && (
         <p className={styles.evalUpdated}>
-          Evaluated on {new Date(evalResult.updatedOn).toLocaleDateString()}
+          Assessed on {new Date(evalResult.updatedOn).toLocaleDateString()}
         </p>
       )}
 
       {/* Quality assessment scores + radar chart */}
       {scores.length > 0 && (
         <div className={styles.evalSection}>
-          <h4 className={styles.evalSectionTitle}>Evaluation</h4>
+          <h4 className={styles.evalSectionTitle}>Assessment</h4>
           <div className={styles.evalContentLayout}>
             <div className={styles.scoreBarList}>
               {scores.map((s) => (

--- a/src/experiences/SkillEvaluation/SkillEvaluationDetails.tsx
+++ b/src/experiences/SkillEvaluation/SkillEvaluationDetails.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Badge, Spinner } from '@fluentui/react-components';
+import { SkillEvaluationResult } from '@/types/skillEvaluation';
+import { EvalScoreBar } from './EvalScoreBar';
+import { EvalAssertionList } from './EvalAssertionList';
+import { EvalRadarChart } from './EvalRadarChart';
+import styles from './SkillEvaluation.module.scss';
+
+interface SkillEvaluationDetailsProps {
+  evalResult?: SkillEvaluationResult;
+  isLoading?: boolean;
+}
+
+export const SkillEvaluationDetails: React.FC<SkillEvaluationDetailsProps> = ({
+  evalResult,
+  isLoading,
+}) => {
+  if (isLoading) {
+    return <Spinner size="small" label="Loading evaluation results..." labelPosition="below" />;
+  }
+
+  if (!evalResult) return null;
+
+  const normalized = evalResult.maxScore > 0
+    ? (evalResult.overallScore / evalResult.maxScore) * 5
+    : 0;
+  const ratio = evalResult.maxScore > 0 ? evalResult.overallScore / evalResult.maxScore : 0;
+
+  function headerBadgeColor(): 'success' | 'warning' | 'danger' {
+    if (ratio >= 0.8) return 'success';
+    if (ratio >= 0.6) return 'warning';
+    return 'danger';
+  }
+
+  const scores = evalResult.qualityAssessment.scores ?? [];
+
+  return (
+    <div className={styles.evalDetails}>
+      {/* Overall header */}
+      <div className={styles.evalHeader}>
+        <Badge
+          appearance="filled"
+          color={headerBadgeColor()}
+          shape="circular"
+          className={styles.evalHeaderBadge}
+        >
+          {normalized.toFixed(1)} <span className={styles.scoreBadgeMax}>/5</span>
+        </Badge>
+        <h3 className={styles.evalHeaderTitle}>AI Quality Score</h3>
+        <Badge
+          appearance="tint"
+          color={evalResult.status === 'pass' ? 'success' : 'danger'}
+          shape="circular"
+        >
+          {evalResult.status === 'pass' ? 'Passed' : 'Failed'}
+        </Badge>
+      </div>
+
+      {evalResult.updatedOn && (
+        <p className={styles.evalUpdated}>
+          Evaluated on {new Date(evalResult.updatedOn).toLocaleDateString()}
+        </p>
+      )}
+
+      {/* Quality assessment scores + radar chart */}
+      {scores.length > 0 && (
+        <div className={styles.evalSection}>
+          <h4 className={styles.evalSectionTitle}>Evaluation</h4>
+          <div className={styles.evalContentLayout}>
+            <div className={styles.scoreBarList}>
+              {scores.map((s) => (
+                <EvalScoreBar key={s.name} score={s} />
+              ))}
+            </div>
+            <div className={styles.radarContainer}>
+              <EvalRadarChart scores={scores} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Structural checks */}
+      <EvalAssertionList title="Structural Checks" tier={evalResult.structuralChecks} />
+
+      {/* Schema validation */}
+      <EvalAssertionList title="Schema Validation" tier={evalResult.schemaValidation} />
+    </div>
+  );
+};
+
+export default React.memo(SkillEvaluationDetails);

--- a/src/experiences/SkillEvaluation/index.ts
+++ b/src/experiences/SkillEvaluation/index.ts
@@ -1,0 +1,5 @@
+export { EvalScoreBadge } from './EvalScoreBadge';
+export { SkillEvaluationDetails } from './SkillEvaluationDetails';
+export { EvalScoreBar } from './EvalScoreBar';
+export { EvalAssertionList } from './EvalAssertionList';
+export { EvalRadarChart } from './EvalRadarChart';

--- a/src/hooks/useSkillEvaluationResult.ts
+++ b/src/hooks/useSkillEvaluationResult.ts
@@ -1,0 +1,18 @@
+import { useRecoilValue } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
+import { SkillEvaluationResult } from '@/types/skillEvaluation';
+import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
+import { useApiService } from '@/hooks/useApiService';
+import { QueryKeys } from '@/constants/QueryKeys';
+
+export function useSkillEvaluationResult(skillName?: string) {
+  const ApiService = useApiService();
+  const isAuthenticated = useRecoilValue(isAuthenticatedAtom);
+
+  return useQuery<SkillEvaluationResult | undefined>({
+    queryKey: [QueryKeys.SkillEvaluationResult, skillName],
+    queryFn: () => ApiService.getSkillEvaluationResult(skillName!),
+    staleTime: Infinity,
+    enabled: Boolean(isAuthenticated && skillName),
+  });
+}

--- a/src/pages/SkillInfo/SkillInfo.tsx
+++ b/src/pages/SkillInfo/SkillInfo.tsx
@@ -52,7 +52,7 @@ export const SkillInfo: React.FC = () => {
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
           <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
-          {evalResult.data && <Tab value="evaluation">Evaluation</Tab>}
+          {evalResult.data && <Tab value="assessment">Assessment</Tab>}
           {hasCustomProps && <Tab value="properties">Additional properties</Tab>}
         </TabList>
       }
@@ -80,7 +80,7 @@ export const SkillInfo: React.FC = () => {
           <EmptyStateMessage>No description available for this skill.</EmptyStateMessage>
         )
       )}
-      {selectedTab === 'evaluation' && (
+      {selectedTab === 'assessment' && (
         <SkillEvaluationDetails evalResult={evalResult.data} isLoading={evalResult.isLoading} />
       )}
       {api.data && selectedTab === 'properties' && (

--- a/src/pages/SkillInfo/SkillInfo.tsx
+++ b/src/pages/SkillInfo/SkillInfo.tsx
@@ -3,9 +3,11 @@ import { useParams } from 'react-router-dom';
 import { Badge, Button, Tab, TabList } from '@fluentui/react-components';
 import { DocumentRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
+import { useSkillEvaluationResult } from '@/hooks/useSkillEvaluationResult';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
 import { HeaderActions } from '@/experiences/HeaderActions';
+import { EvalScoreBadge, SkillEvaluationDetails } from '@/experiences/SkillEvaluation';
 import { buildSkillDeeplink } from '@/utils/skillDeeplink';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
@@ -18,6 +20,7 @@ const SKILL_SOURCE_URL = 'https://github.com/vercel-labs/agent-skills/tree/main/
 export const SkillInfo: React.FC = () => {
   const { name } = useParams<{ name: string }>();
   const api = useApi(name);
+  const evalResult = useSkillEvaluationResult(name);
   const [selectedTab, setSelectedTab] = useState<string>('documentation');
 
   setDocumentTitle(`Skill${api.data?.title ? ` - ${api.data.title}` : ''}`);
@@ -42,12 +45,14 @@ export const SkillInfo: React.FC = () => {
       metadata={
         <>
           <Badge appearance="filled" color="brand" shape="circular">Skill</Badge>
+          <EvalScoreBadge evalResult={evalResult.data} />
           {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </>
       }
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
           <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
+          {evalResult.data && <Tab value="evaluation">Evaluation</Tab>}
           {hasCustomProps && <Tab value="properties">Additional properties</Tab>}
         </TabList>
       }
@@ -74,6 +79,9 @@ export const SkillInfo: React.FC = () => {
         ) : (
           <EmptyStateMessage>No description available for this skill.</EmptyStateMessage>
         )
+      )}
+      {selectedTab === 'evaluation' && (
+        <SkillEvaluationDetails evalResult={evalResult.data} isLoading={evalResult.isLoading} />
       )}
       {api.data && selectedTab === 'properties' && (
         <CustomMetadata value={api.data.customProperties} />

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -12,6 +12,7 @@ import { IApiService, PaginatedResult } from '@/types/services/IApiService';
 import { Server, ServerResponse } from '@/types/server';
 import { MetadataSchema } from '@/types/metadataSchema';
 import { PluginDetails } from '@/types/plugin';
+import { SkillEvaluationResult } from '@/types/skillEvaluation';
 import { DEFAULT_PAGE_SIZE } from '@/constants';
 
 export const ApiService: IApiService = {
@@ -131,5 +132,11 @@ export const ApiService: IApiService = {
   async getMetadataSchemas(): Promise<MetadataSchema[]> {
     const response = await HttpService.get<MetadataSchema[]>(`/metadataSchemas?$top=${DEFAULT_PAGE_SIZE}`, { skipWorkspacePrefix: true });
     return response || [];
+  },
+
+  async getSkillEvaluationResult(skillName: string): Promise<SkillEvaluationResult | undefined> {
+    return await HttpService.getOptional<SkillEvaluationResult>(
+      `/skills/${skillName}/evaluationResults/default`
+    );
   },
 };

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -97,6 +97,44 @@ export const HttpService = {
     return (await response.json()) as T;
   },
 
+  /** GET that returns `undefined` on 404 instead of throwing / returning error JSON. */
+  async getOptional<T>(endpoint: string, options?: RequestOptions): Promise<T | undefined> {
+    try {
+      const { AuthService } = getRecoil(appServicesAtom);
+      const config = getRecoil(configAtom);
+      const accessToken = await AuthService.getAccessToken();
+
+      const init: RequestInit = {
+        method: 'GET',
+        headers: new Headers(BASE_HEADERS),
+      };
+
+      if (accessToken) {
+        (init.headers as Headers).append('Authorization', 'Bearer ' + accessToken);
+      }
+
+      let baseUrl = `https://${config.dataApiHostName}`;
+      if (!options?.skipWorkspacePrefix && !config.dataApiHostName.includes('/workspaces/default')) {
+        baseUrl += '/workspaces/default';
+      }
+
+      const response = await fetch(`${baseUrl}${endpoint}`, init);
+
+      if (response.status === 404) return undefined;
+
+      if (response.status === 401 || response.status === 403) {
+        if (accessToken) {
+          setRecoil(isAccessDeniedAtom, true);
+          return undefined;
+        }
+      }
+
+      return (await response.json()) as T;
+    } catch {
+      return undefined;
+    }
+  },
+
   post<T>(endpoint: string, payload?: any): Promise<T | undefined> {
     return makeRequest<T>(endpoint, 'POST', payload);
   },

--- a/src/types/services/IApiService.ts
+++ b/src/types/services/IApiService.ts
@@ -8,6 +8,7 @@ import { ApiAuthScheme, ApiAuthSchemeMetadata } from '@/types/apiAuth';
 import { Server } from '@/types/server';
 import { MetadataSchema } from '@/types/metadataSchema';
 import { PluginDetails } from '@/types/plugin';
+import { SkillEvaluationResult } from '@/types/skillEvaluation';
 
 export interface PaginatedResult<T> {
   value: T[];
@@ -30,4 +31,5 @@ export interface IApiService {
   getSecurityCredentials(definitionId: ApiDefinitionId, schemeName: string): Promise<ApiAuthScheme>;
   getMetadataSchemas(): Promise<MetadataSchema[]>;
   getPlugin(name: string): Promise<PluginDetails>;
+  getSkillEvaluationResult(skillName: string): Promise<SkillEvaluationResult | undefined>;
 }

--- a/src/types/skillEvaluation.ts
+++ b/src/types/skillEvaluation.ts
@@ -1,0 +1,40 @@
+/** Response contract for `GET /workspaces/{ws}/skills/{name}/evaluationResults/{resultName}`. */
+export interface SkillEvaluationResult {
+  skillName: string;
+  status: EvalStatus;
+  overallScore: number;
+  maxScore: number;
+  evaluationConfigurationName: string;
+  updatedOn: string;
+  structuralChecks: EvalTierResult<EvalAssertion>;
+  schemaValidation: EvalTierResult<EvalAssertion>;
+  qualityAssessment: EvalTierResult<EvalJudgeScore>;
+}
+
+export type EvalStatus = 'pass' | 'fail';
+
+export interface EvalTierResult<T = unknown> {
+  status: EvalStatus;
+  passed: number;
+  total: number;
+  weightedScore: number | null;
+  maxWeightedScore: number | null;
+  /** Present on structuralChecks / schemaValidation tiers. */
+  assertions?: T[];
+  /** Present on qualityAssessment tier. */
+  scores?: T[];
+}
+
+export interface EvalAssertion {
+  name: string;
+  status: EvalStatus;
+  message: string;
+}
+
+export interface EvalJudgeScore {
+  name: string;
+  score: number;
+  maxScore: number;
+  passed: boolean;
+  reasoning: string;
+}


### PR DESCRIPTION
## Summary

Add skill assessment results to the Skill detail page, including quality scores, structural checks, schema validation, and a radar chart visualization.

## Changes

### 1. Skill assessment results on detail page (ca91c8c)
- New **Assessment** tab on the SkillInfo page with per-criterion quality scores
- Score badge in header metadata area with dynamic colors (green/yellow/red based on ratio)
- Colored progress bars for each quality criterion
- Assertion lists for structural checks and schema validation with pass/fail indicators
- `SkillEvaluationResult` types matching the Data API contract
- `getSkillEvaluationResult` service method with 404-safe HTTP GET
- `useSkillEvaluationResult` React Query hook
- New components: `EvalScoreBadge`, `EvalScoreBar`, `EvalAssertionList`, `SkillEvaluationDetails`

### 2. Radar chart for quality scores (70caaad)
- Added `recharts` dependency (MIT licensed)
- `EvalRadarChart` component visualizing quality assessment criteria as a radar/spider chart
- Dots color-coded by score ratio (green/orange/red) with numeric values
- Long axis labels auto-wrap to multiple lines

### 3. Use proper wording for Assessment in UI (8be34f4)
- All user-visible text updated from "Evaluation" to "Assessment"
- Tab label, spinner text, date line, and section heading renamed
- Internal code identifiers unchanged

## Files changed
- 22 files changed, ~1096 insertions, ~8 deletions
