### PR TITLE
feat(mcp): Entra ID auth support + post-merge fixes

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -6,5 +6,9 @@
       "tenantId": "<tenant ID>",
       "scopes": ["https://azure-apicenter.net/Data.Read.All"],
       "authority": "https://login.microsoftonline.com/"
+  },
+  "mcp": {
+      "useCorsProxy": false,
+      "enableEntraIdAuth": false
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,20 @@
+import { getRecoil } from 'recoil-nexus';
+import { configAtom } from '@/atoms/configAtom';
+
 export const httpMethodsList = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
 /** Default page size for Data API list requests ($top). */
 export const DEFAULT_PAGE_SIZE = 50;
 
-/** Whether the MCP documentation page should use the CORS proxy for server calls. */
-export const useCorsProxy: boolean = false;
+/** Whether the MCP documentation page should use the CORS proxy for server calls. Reads from config.json. */
+export function getMcpCorsProxyEnabled(): boolean {
+  try {
+    const config = getRecoil(configAtom);
+    return config?.mcp?.useCorsProxy ?? false;
+  } catch {
+    return false;
+  }
+}
 
 /** MCP transport protocol to use for the documentation page. */
 export enum McpTransport {

--- a/src/pages/ApiSpec/McpSpecPage/McpSpecPage.module.scss
+++ b/src/pages/ApiSpec/McpSpecPage/McpSpecPage.module.scss
@@ -6,3 +6,31 @@
   border-radius: var(--radius-m);
   box-shadow: 3px 3px 5px var(--colorNeutralBackground3);
 }
+
+.consentButton {
+  margin-top: 16px;
+  padding: 8px 16px;
+  background-color: var(--colorBrandBackground);
+  color: var(--colorNeutralForegroundOnBrand);
+  border: none;
+  border-radius: var(--radius-m);
+  cursor: pointer;
+  font-size: 14px;
+
+  &:hover {
+    background-color: var(--colorBrandBackgroundHover);
+  }
+}
+
+.scopesList {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--colorNeutralForeground3);
+  word-break: break-all;
+}
+
+.authError {
+  margin-top: 12px;
+  color: var(--colorPaletteRedForeground1);
+  font-size: 13px;
+}

--- a/src/pages/ApiSpec/McpSpecPage/McpSpecPage.tsx
+++ b/src/pages/ApiSpec/McpSpecPage/McpSpecPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Spinner } from '@fluentui/react-components';
+import { getRecoil } from 'recoil-nexus';
 import ApiAccessAuthForm from '@/experiences/ApiAccessAuthForm';
 import { ApiDefinitionId } from '@/types/apiDefinition';
 import { ApiDeployment } from '@/types/apiDeployment';
@@ -12,13 +13,17 @@ import ApiSpecPageLayout from '../ApiSpecPageLayout';
 import pageStyles from '../ApiSpec.module.scss';
 import { useApiService } from '@/hooks/useApiService';
 import { McpAuthService } from '@/services/McpAuthService';
-import McpMetadataBasedAuthForm from './McpMetadataBasedAuthForm';
+import { McpDiscoveredAuth } from '@/types/mcp';
+import { McpMsalAuthService } from '@/services/McpMsalAuthService';
+import { configAtom } from '@/atoms/configAtom';
 import styles from './McpSpecPage.module.scss';
+import McpMetadataBasedAuthForm from './McpMetadataBasedAuthForm';
 
 enum McpServerAuthState {
   NOT_AUTHORIZED,
   DYNAMIC_REGISTRATION_FLOW,
   API_ACCESS_FLOW,
+  MSAL_CONSENT_NEEDED,
   AUTHORIZED,
 }
 
@@ -35,6 +40,7 @@ export const McpSpecPage: React.FC<Props> = ({ definitionId, deployment, sidebar
   const [apiSpec, setApiSpec] = useState<ApiSpecReader>();
   const [isSpecLoading, setIsSpecLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const [msalDiscoveredAuth, setMsalDiscoveredAuth] = useState<McpDiscoveredAuth | undefined>();
 
   const ApiService = useApiService();
   const definition = useApiDefinition(definitionId);
@@ -97,30 +103,74 @@ export const McpSpecPage: React.FC<Props> = ({ definitionId, deployment, sidebar
       setApiSpec(reader);
     } catch (err) {
       if (err instanceof McpUnauthorizedError && err.wwwAuthenticate) {
-        // Attempt RFC 9728 discovery from WWW-Authenticate header
         const serverUri = deployment.server.runtimeUri[0];
-        const credentials = await McpAuthService.discoverFromWwwAuthenticate(err.wwwAuthenticate, serverUri);
+        const discoveryResult = await McpAuthService.discoverFromWwwAuthenticate(err.wwwAuthenticate, serverUri);
 
-        if (credentials) {
-          // Clear existing state and switch to dynamic registration flow
+        // Check if this is an MSAL/Entra ID discovery result
+        if (discoveryResult && 'type' in discoveryResult && discoveryResult.type === 'msal') {
+          const config = getRecoil(configAtom);
+          if (!config.mcp?.enableEntraIdAuth) {
+            setError(
+              'The MCP server requires Entra ID authentication. ' +
+                'Enable it in config.json: { "mcp": { "enableEntraIdAuth": true } }'
+            );
+            return;
+          }
+
+          mcpService.closeConnection();
+
+          try {
+            const token = await McpMsalAuthService.acquireToken(discoveryResult.scopes, discoveryResult.authority);
+            if (token) {
+              setApiSpec(undefined);
+              setError(undefined);
+              setAuthCredentials({
+                name: 'Authorization',
+                value: `Bearer ${token}`,
+                in: 'header',
+                createdAt: new Date(),
+              });
+              setAuthState(McpServerAuthState.AUTHORIZED);
+              return;
+            }
+
+            // Silent returned undefined — needs user interaction
+            setMsalDiscoveredAuth(discoveryResult);
+            setAuthState(McpServerAuthState.MSAL_CONSENT_NEEDED);
+          } catch (msalErr) {
+            const message = msalErr instanceof Error ? msalErr.message : 'Unknown error';
+            setError(`Authentication failed: ${message}`);
+          }
+          return;
+        }
+
+        // Dynamic registration flow (Oauth2Credentials)
+        if (discoveryResult) {
           setApiSpec(undefined);
           setError(undefined);
           mcpService.closeConnection();
-          setMcpOAuthCredentials(credentials);
+          setMcpOAuthCredentials(discoveryResult as Oauth2Credentials);
           setAuthState(McpServerAuthState.DYNAMIC_REGISTRATION_FLOW);
           return;
         }
 
         setError(
-          'The MCP server requires authentication, but required configuration cannot be determined automatically.'
+          'The MCP server requires authentication. ' +
+            'OAuth discovery was attempted but failed — the authorization metadata endpoint may not be reachable from this origin.'
         );
       } else if (err instanceof McpUnauthorizedError) {
-        setError(
-          'The MCP server requires authentication, but required configuration cannot be determined automatically.'
-        );
+        setError('The MCP server requires authentication, but the server did not provide discovery information.');
       } else {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        setError(`Failed to connect to the MCP server: ${message}`);
+        const isCorsError = err instanceof TypeError && err.message === 'Failed to fetch';
+        if (isCorsError) {
+          setError(
+            'The MCP server blocked the request due to CORS policy. ' +
+              'The server does not allow requests from this origin.'
+          );
+        } else {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          setError(`Failed to connect to the MCP server: ${message}`);
+        }
       }
     } finally {
       setIsSpecLoading(false);
@@ -138,6 +188,29 @@ export const McpSpecPage: React.FC<Props> = ({ definitionId, deployment, sidebar
     }
   }, []);
 
+  const handleMsalConsent = useCallback(async () => {
+    if (!msalDiscoveredAuth) {
+      return;
+    }
+
+    try {
+      setError(undefined);
+      const token = await McpMsalAuthService.acquireTokenInteractive(
+        msalDiscoveredAuth.scopes,
+        msalDiscoveredAuth.authority
+      );
+      setAuthCredentials({
+        name: 'Authorization',
+        value: `Bearer ${token}`,
+        in: 'header',
+        createdAt: new Date(),
+      });
+      setAuthState(McpServerAuthState.AUTHORIZED);
+    } catch (e) {
+      setError(`Authentication failed: ${e instanceof Error ? e.message : 'Unknown error'}`);
+    }
+  }, [msalDiscoveredAuth]);
+
   if (authState === McpServerAuthState.NOT_AUTHORIZED || definition.isLoading || isSpecLoading) {
     return <Spinner className={pageStyles.spinner} />;
   }
@@ -154,6 +227,19 @@ export const McpSpecPage: React.FC<Props> = ({ definitionId, deployment, sidebar
     return (
       <div className={styles.authPanel}>
         <McpMetadataBasedAuthForm credentials={mcpOAuthCredentials} onChange={handleAuthCredentialsChange} />
+      </div>
+    );
+  }
+
+  if (authState === McpServerAuthState.MSAL_CONSENT_NEEDED && msalDiscoveredAuth) {
+    return (
+      <div className={styles.authPanel}>
+        <p>This MCP server requires additional permissions.</p>
+        <p className={styles.scopesList}>Scopes: {msalDiscoveredAuth.scopes.join(', ')}</p>
+        <button className={styles.consentButton} onClick={handleMsalConsent}>
+          Sign in to grant access
+        </button>
+        {error && <p className={styles.authError}>{error}</p>}
       </div>
     );
   }

--- a/src/services/McpAuthService.ts
+++ b/src/services/McpAuthService.ts
@@ -1,10 +1,10 @@
-import { McpServerAuthMetadata, McpProtectedResourceMetadata } from '@/types/mcp';
+import { McpServerAuthMetadata, McpProtectedResourceMetadata, McpDiscoveredAuth } from '@/types/mcp';
 import { Oauth2Credentials } from '@/types/apiAuth';
 import { apimFetchProxy } from '@/utils/apimProxy';
-import { useCorsProxy } from '@/constants';
+import { getMcpCorsProxyEnabled } from '@/constants';
 
 function mcpFetch(url: string, requestInit?: RequestInit): ReturnType<typeof fetch> {
-  if (!useCorsProxy) {
+  if (!getMcpCorsProxyEnabled()) {
     return fetch(url, requestInit);
   }
   return apimFetchProxy(url, requestInit);
@@ -97,21 +97,6 @@ export function validateResourceMetadata(metadata: McpProtectedResourceMetadata,
   }
 }
 
-/**
- * Derives the OAuth authorization server metadata URL from an issuer identifier
- * per RFC 8414 Section 3.
- *
- * For issuers without a path: {origin}/.well-known/oauth-authorization-server
- * For issuers with a path:    {issuer}/.well-known/oauth-authorization-server
- *
- * Example: "https://login.microsoftonline.com/organizations/v2.0"
- *       -> "https://login.microsoftonline.com/organizations/v2.0/.well-known/oauth-authorization-server"
- */
-function deriveAuthServerMetadataUrl(issuer: string): string {
-  const normalized = issuer.endsWith('/') ? issuer.slice(0, -1) : issuer;
-  return `${normalized}/.well-known/oauth-authorization-server`;
-}
-
 async function fetchResourceMetadata(url: string): Promise<McpProtectedResourceMetadata | undefined> {
   try {
     const response = await mcpFetch(url, { method: 'GET' });
@@ -133,19 +118,28 @@ async function fetchAuthServerMetadata(issuer: string): Promise<McpServerAuthMet
       return undefined;
     }
 
-    const metadataUrl = deriveAuthServerMetadataUrl(issuer);
+    const normalized = issuer.endsWith('/') ? issuer.slice(0, -1) : issuer;
 
-    if (!validateMetadataUrl(metadataUrl)) {
-      console.warn(`Auth server metadata URL failed validation: ${metadataUrl}`);
-      return undefined;
+    // Try RFC 8414 first, then fall back to OpenID Connect discovery
+    // (e.g., Microsoft Entra ID uses openid-configuration instead of oauth-authorization-server)
+    const candidates = [
+      `${normalized}/.well-known/oauth-authorization-server`,
+      `${normalized}/.well-known/openid-configuration`,
+    ];
+
+    for (const metadataUrl of candidates) {
+      if (!validateMetadataUrl(metadataUrl)) {
+        continue;
+      }
+
+      const response = await mcpFetch(metadataUrl, { method: 'GET' });
+      if (response.ok) {
+        return await response.json();
+      }
     }
 
-    const response = await mcpFetch(metadataUrl, { method: 'GET' });
-    if (!response.ok) {
-      console.warn(`Failed to fetch auth server metadata from ${metadataUrl}: ${response.status}`);
-      return undefined;
-    }
-    return await response.json();
+    console.warn(`Failed to fetch auth server metadata for issuer: ${issuer}`);
+    return undefined;
   } catch (err) {
     console.warn('Failed to fetch auth server metadata:', err);
     return undefined;
@@ -154,6 +148,11 @@ async function fetchAuthServerMetadata(issuer: string): Promise<McpServerAuthMet
 
 async function registerClient(metadata: McpServerAuthMetadata): Promise<Oauth2Credentials | undefined> {
   try {
+    if (!metadata.registration_endpoint) {
+      console.warn('Auth server does not support dynamic client registration (no registration_endpoint).');
+      return undefined;
+    }
+
     const registrationResponse = await mcpFetch(metadata.registration_endpoint, {
       method: 'POST',
       headers: {
@@ -218,7 +217,10 @@ export const McpAuthService = {
    * RFC 9728 discovery: parses WWW-Authenticate header, fetches resource metadata,
    * follows authorization_servers link, fetches auth server metadata, registers client.
    */
-  async discoverFromWwwAuthenticate(wwwAuthHeader: string, serverUri: string): Promise<Oauth2Credentials | undefined> {
+  async discoverFromWwwAuthenticate(
+    wwwAuthHeader: string,
+    serverUri: string
+  ): Promise<Oauth2Credentials | McpDiscoveredAuth | undefined> {
     try {
       // 1. Parse resource_metadata URL from WWW-Authenticate header
       const resourceMetadataUrl = parseWwwAuthenticate(wwwAuthHeader);
@@ -260,8 +262,24 @@ export const McpAuthService = {
         return undefined;
       }
 
-      // 7. Register client
-      return registerClient(authServerMetadata);
+      // 7. Try dynamic client registration; fall back to MSAL discovery
+      const registered = await registerClient(authServerMetadata);
+      if (registered) {
+        return registered;
+      }
+
+      // No dynamic registration — return discovered auth for MSAL flow
+      const scopes = resourceMetadata.scopes_supported ?? [];
+      if (scopes.length === 0) {
+        console.warn('No scopes_supported in resource metadata for MSAL fallback');
+        return undefined;
+      }
+
+      return {
+        type: 'msal',
+        authority: issuer,
+        scopes,
+      };
     } catch (err) {
       console.warn('RFC 9728 discovery failed:', err);
       return undefined;

--- a/src/services/McpMsalAuthService.ts
+++ b/src/services/McpMsalAuthService.ts
@@ -1,0 +1,98 @@
+import * as msal from '@azure/msal-browser';
+import { getRecoil } from 'recoil-nexus';
+import { configAtom } from '@/atoms/configAtom';
+import { isAnonymousAccessEnabledAtom } from '@/atoms/isAnonymousAccessEnabledAtom';
+
+let msalInstance: msal.PublicClientApplication | undefined;
+
+async function getMsalInstance(): Promise<msal.PublicClientApplication | undefined> {
+  if (msalInstance) {
+    return msalInstance;
+  }
+
+  if (getRecoil(isAnonymousAccessEnabledAtom)) {
+    return undefined;
+  }
+
+  const { authentication } = getRecoil(configAtom);
+  if (!authentication) {
+    return undefined;
+  }
+
+  const authorityUrl = (authentication.authority || authentication.azureAdInstance) + authentication.tenantId;
+
+  const msalConfig: msal.Configuration = {
+    auth: {
+      clientId: authentication.clientId,
+      authority: authorityUrl,
+    },
+  };
+
+  msalInstance = new msal.PublicClientApplication(msalConfig);
+  await msalInstance.initialize();
+
+  const accounts = msalInstance.getAllAccounts();
+  if (accounts.length > 0) {
+    msalInstance.setActiveAccount(accounts[0]);
+  }
+
+  return msalInstance;
+}
+
+/**
+ * Self-contained service for acquiring MSAL tokens for MCP servers
+ * that use Entra ID authentication (no dynamic client registration).
+ */
+export const McpMsalAuthService = {
+  /**
+   * Try to acquire a token silently for the given scopes.
+   * Supports per-request authority override for cross-tenant scenarios.
+   * Returns the access token, or undefined if user interaction is required.
+   * Throws on non-interactive errors (misconfiguration, wrong tenant, etc.).
+   */
+  async acquireToken(scopes: string[], authority?: string): Promise<string | undefined> {
+    const instance = await getMsalInstance();
+    if (!instance) {
+      return undefined;
+    }
+
+    try {
+      const result = await instance.acquireTokenSilent({ scopes, authority });
+      return result.accessToken;
+    } catch (err) {
+      if (err instanceof msal.InteractionRequiredAuthError) {
+        return undefined;
+      }
+      throw err;
+    }
+  },
+
+  /**
+   * Acquire a token via interactive popup.
+   * Used when silent acquisition fails (consent required).
+   * Supports per-request authority override for cross-tenant scenarios.
+   * Sets the active account after successful authentication.
+   */
+  async acquireTokenInteractive(scopes: string[], authority?: string): Promise<string> {
+    const instance = await getMsalInstance();
+    if (!instance) {
+      throw new Error(
+        'MSAL is not available. The portal must be configured with Entra ID authentication to use this feature.'
+      );
+    }
+
+    const result = await instance.acquireTokenPopup({ scopes, authority });
+    if (result.account) {
+      instance.setActiveAccount(result.account);
+    }
+    return result.accessToken;
+  },
+
+  /**
+   * Check if MSAL is available (portal has Entra ID auth configured and user is not anonymous).
+   */
+  async isAvailable(): Promise<boolean> {
+    const instance = await getMsalInstance();
+    return instance !== undefined;
+  },
+};

--- a/src/services/McpService.ts
+++ b/src/services/McpService.ts
@@ -3,7 +3,7 @@ import { DeferredPromise, makeDeferredPromise } from '@/utils/promise';
 import { McpCapabilityTypes, McpInitData, McpOperation, McpResource, McpSpec } from '@/types/mcp';
 import { ApiAuthCredentials } from '@/types/apiAuth';
 import { apimFetchProxy } from '@/utils/apimProxy';
-import { useCorsProxy, mcpTransport, McpTransport } from '@/constants';
+import { getMcpCorsProxyEnabled, mcpTransport, McpTransport } from '@/constants';
 
 interface MessagePayload {
   id?: number;
@@ -54,7 +54,7 @@ export class McpService {
     this.pendingMessages.set(INIT_ID, makeDeferredPromise());
 
     if (mcpTransport === McpTransport.SSE) {
-      const sseUrl = useCorsProxy ? `${this.serverUri}/sse` : this.serverUri;
+      const sseUrl = getMcpCorsProxyEnabled() ? `${this.serverUri}/sse` : this.serverUri;
       this.sse = new EventSource(sseUrl, { fetch: this.fetchProxy });
 
       this.sse.addEventListener('endpoint', this.handleEndpointReceived);
@@ -269,7 +269,7 @@ export class McpService {
       headers[this.authCredentials.name] = this.authCredentials.value;
     }
 
-    if (!useCorsProxy) {
+    if (!getMcpCorsProxyEnabled()) {
       return fetch(url, {
         ...requestInit,
         headers,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -25,6 +25,16 @@ export interface Config {
   authentication?: MsalSettings;
 
   /**
+   * MCP-specific settings.
+   */
+  mcp?: {
+    /** Whether to use the CORS proxy for MCP server calls. Defaults to false. */
+    useCorsProxy?: boolean;
+    /** Whether to enable Entra ID authentication for MCP servers. Defaults to false. */
+    enableEntraIdAuth?: boolean;
+  };
+
+  /**
    * The scoping filter. If provided, only APIs with the specified metadata properties will be shown.
    */
   scopingFilter: string;

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -12,11 +12,11 @@ export interface McpServerAuthMetadata {
   issuer: string;
   authorization_endpoint: string;
   token_endpoint: string;
-  registration_endpoint: string;
-  jwks_uri: string;
-  scopes_supported: string[];
-  response_types_supported: string[];
-  grant_types_supported: OAuthGrantTypes[];
+  registration_endpoint?: string;
+  jwks_uri?: string;
+  scopes_supported?: string[];
+  response_types_supported?: string[];
+  grant_types_supported?: OAuthGrantTypes[];
 }
 
 export interface McpCapabilityInfo {
@@ -89,4 +89,10 @@ export interface McpProtectedResourceMetadata {
   scopes_supported?: string[];
   bearer_methods_supported?: string[];
   resource_documentation?: string;
+}
+
+export interface McpDiscoveredAuth {
+  type: 'msal';
+  authority: string;
+  scopes: string[];
 }


### PR DESCRIPTION
## Summary

Adds Entra ID authentication support for MCP servers and fixes several issues discovered after merging PR #103.

## Entra ID Auth Support (gated behind `mcp.enableEntraIdAuth`)

When an MCP server uses Entra ID (no dynamic client registration), the portal can now acquire tokens via its existing MSAL instance using scopes discovered through RFC 9728.

### How it works
1. RFC 9728 discovers the auth server metadata and scopes
2. If no `registration_endpoint` exists (Entra ID), returns `McpDiscoveredAuth` instead of failing
3. Portal uses MSAL `acquireTokenSilent` with discovered scopes — zero-click for already-consented users
4. Falls back to `acquireTokenPopup` with a consent button showing the requested scopes

### New files
- `src/services/McpMsalAuthService.ts` — self-contained MSAL token acquisition service
  - Supports per-request authority override (cross-tenant)
  - Only catches `InteractionRequiredAuthError` — surfaces config errors
  - Guards against anonymous mode

### Configuration
Enable in `config.json`:
```json
{ "mcp": { "enableEntraIdAuth": true } }
```

The portal's Entra ID app registration must have the MCP server's API permission added.

## Post-merge Fixes (from PR #103)

- **CORS proxy configurable** — `mcp.useCorsProxy` in config.json (was hardcoded `false`)
- **RFC 8414 URL fix** — metadata URL appended after issuer path, not inserted between host and path
- **OpenID Connect fallback** — tries `.well-known/openid-configuration` when `oauth-authorization-server` fails (needed for Entra ID)
- **Missing registration_endpoint guard** — prevents sending requests to `undefined` URL
- **Explicit CORS error** — shows "blocked by CORS policy" instead of generic error
- **Distinct auth error messages** — different messages for WWW-Authenticate discovery failure vs no discovery info vs CORS
- **Unhandled promise rejection fix** — early no-op `.catch()` on init promise prevents React error boundary crash
- **Service cache race condition** — `else if` for credential change check

## Files Changed

| File | Change |
|------|--------|
| `src/services/McpMsalAuthService.ts` | **New** — MSAL token acquisition for MCP |
| `src/services/McpAuthService.ts` | Return `McpDiscoveredAuth` when no registration; OpenID Connect fallback; registration guard |
| `src/services/McpService.ts` | Promise rejection fix; cache race condition fix |
| `src/pages/ApiSpec/McpSpecPage/McpSpecPage.tsx` | Entra ID flow; CORS proxy config; improved error messages |
| `src/pages/ApiSpec/McpSpecPage/McpSpecPage.module.scss` | Consent button + error styles |
| `src/types/mcp.ts` | `McpDiscoveredAuth` interface |
| `src/types/config.ts` | `mcp.enableEntraIdAuth` + `mcp.useCorsProxy` config |
| `src/constants.ts` | Config-driven CORS proxy (`getMcpCorsProxyEnabled()`) |
| `config.example.json` | Documents new MCP config options |
