### PR TITLE
refactor: swap custom cards for Fluent 2 Card components

### DIFF
--- a/src/components/ApiCard/ApiCard.tsx
+++ b/src/components/ApiCard/ApiCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Badge } from '@fluentui/react-components';
+import { Badge, Card, CardHeader, Text, makeStyles, tokens, shorthands } from '@fluentui/react-components';
 import { formatKindDisplay } from '@/utils/formatKind';
-import styles from './ApiCard.module.scss';
 
 export interface ApiCardApi {
   name: string;
@@ -13,7 +12,7 @@ export interface ApiCardApi {
 
 interface Props {
   api: ApiCardApi;
-  linkProps?: React.HTMLProps<HTMLAnchorElement>;
+  onClick?: (e: React.MouseEvent) => void;
   showType?: boolean;
 }
 
@@ -26,25 +25,56 @@ function getCategoryLabel(type?: string): string {
   return 'API';
 }
 
-export const ApiCard: React.FC<Props> = ({ api, showType, linkProps }) => (
-  <a
-    {...linkProps}
-    className={styles.apiCard}
-    title={api.displayName}
-  >
-    <div className={styles.cardContent}>
+const useStyles = makeStyles({
+  card: {
+    minHeight: '200px',
+    height: '100%',
+    boxSizing: 'border-box',
+    cursor: 'pointer',
+    boxShadow: tokens.shadow8,
+  },
+  tags: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalS,
+  },
+  description: {
+    display: '-webkit-box',
+    WebkitLineClamp: 4,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  },
+});
+
+export const ApiCard: React.FC<Props> = ({ api, showType, onClick }) => {
+  const classes = useStyles();
+
+  return (
+    <Card
+      className={classes.card}
+      focusMode="tab-exit"
+      onClick={onClick}
+      aria-label={api.displayName}
+    >
       {showType && (
-        <div className={styles.tags}>
+        <div className={classes.tags}>
           <Badge appearance="filled" color="brand" shape="circular">{getCategoryLabel(api.type)}</Badge>
           {!!api.type && !STANDALONE_KINDS.includes(api.type.toLowerCase()) && (
             <Badge appearance="tint" color="brand" shape="circular">{formatKindDisplay(api.type)}</Badge>
           )}
         </div>
       )}
-      <h4 className={styles.title}>{api.displayName}</h4>
-      {api.description && <p className={styles.description}>{api.description}</p>}
-    </div>
-  </a>
-);
+      <CardHeader
+        header={<Text weight="semibold" size={400}>{api.displayName}</Text>}
+        description={
+          api.description ? (
+            <Text className={classes.description} size={300}>
+              {api.description}
+            </Text>
+          ) : undefined
+        }
+      />
+    </Card>
+  );
+};
 
 export default React.memo(ApiCard);

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -45,35 +45,30 @@ export const ApiList: React.FC = () => {
     return adapted;
   }, [apis.data]);
 
-  const apiLinkPropsProvider = useCallback(
+  const getApiUrl = useCallback(
     (api: ApiCardApi) => {
-      const typedApi = api as ApiCardApi & { type?: string };
-      const kind = typedApi.type?.toLowerCase();
-      let url: string;
-      if (kind === 'agent') {
-        url = LocationsService.getAgentChatUrl(api.name);
-      } else if (kind === 'skill') {
-        url = LocationsService.getSkillInfoUrl(api.name);
-      } else if (kind === 'plugin') {
-        url = LocationsService.getPluginInfoUrl(api.name);
-      } else if (kind === 'languagemodel') {
-        url = LocationsService.getModelPlaygroundUrl(api.name);
-      } else {
-        url = LocationsService.getApiDetailUrl(api.name);
-      }
+      const kind = (api as ApiCardApi & { type?: string }).type?.toLowerCase();
+      if (kind === 'agent') return LocationsService.getAgentChatUrl(api.name);
+      if (kind === 'skill') return LocationsService.getSkillInfoUrl(api.name);
+      if (kind === 'plugin') return LocationsService.getPluginInfoUrl(api.name);
+      if (kind === 'languagemodel') return LocationsService.getModelPlaygroundUrl(api.name);
+      return LocationsService.getApiDetailUrl(api.name);
+    },
+    []
+  );
 
-      return {
-        href: url,
-        onClick: (e: React.MouseEvent) => {
-          if (e.ctrlKey || e.button !== 0) {
-            return;
-          }
-          e.preventDefault();
-          navigate(url);
-        },
+  const apiClickHandler = useCallback(
+    (api: ApiCardApi) => {
+      return (e: React.MouseEvent) => {
+        const url = getApiUrl(api);
+        if (e.ctrlKey || e.metaKey || e.button !== 0) {
+          window.open(url, '_blank');
+          return;
+        }
+        navigate(url);
       };
     },
-    [navigate]
+    [navigate, getApiUrl]
   );
 
   const handleLoadMore = useCallback(
@@ -123,7 +118,7 @@ export const ApiList: React.FC = () => {
             <ContributeCard url={config.contributions!.gitRepositoryUrl} />
           )}
           {adaptedApiList.map((api) => (
-            <ApiCard key={api.name} api={api} linkProps={apiLinkPropsProvider(api)} showType />
+            <ApiCard key={api.name} api={api} onClick={apiClickHandler(api)} showType />
           ))}
         </div>
         {renderLoadMore()}
@@ -137,7 +132,7 @@ export const ApiList: React.FC = () => {
         {adaptedApiList.map((api) => (
           <InfoTable.Row key={api.name}>
             <InfoTable.Cell>
-              <Link {...apiLinkPropsProvider(api)}>{api.title}</Link>
+              <Link href={getApiUrl(api)} onClick={(e) => { e.preventDefault(); navigate(getApiUrl(api)); }}>{api.title}</Link>
             </InfoTable.Cell>
             <InfoTable.Cell>
               <MarkdownRenderer markdown={api.description} maxLength={120} />

--- a/src/experiences/ContributeCard/ContributeCard.tsx
+++ b/src/experiences/ContributeCard/ContributeCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from './ContributeCard.module.scss';
+import { Card, Text, makeStyles, tokens, shorthands } from '@fluentui/react-components';
 
 interface Props {
   url: string;
@@ -11,17 +11,39 @@ const GitHubIcon: React.FC<{ className?: string }> = ({ className }) => (
   </svg>
 );
 
-export const ContributeCard: React.FC<Props> = ({ url }) => (
-  <a
-    className={styles.contributeCard}
-    href={url}
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    <GitHubIcon className={styles.icon} />
-    <h3 className={styles.title}>+ Contribute</h3>
-    <p className={styles.subtitle}>Share plugins, skills, and agents</p>
-  </a>
-);
+const useStyles = makeStyles({
+  card: {
+    minHeight: '200px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: tokens.spacingVerticalM,
+    cursor: 'pointer',
+    boxShadow: tokens.shadow8,
+  },
+  icon: {
+    width: '48px',
+    height: '48px',
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
+export const ContributeCard: React.FC<Props> = ({ url }) => {
+  const classes = useStyles();
+
+  return (
+    <Card
+      className={classes.card}
+      focusMode="tab-exit"
+      onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
+      aria-label="Contribute — Share plugins, skills, and agents"
+    >
+      <GitHubIcon className={classes.icon} />
+      <Text weight="semibold" size={400}>+ Contribute</Text>
+      <Text size={300} align="center">Share plugins, skills, and agents</Text>
+    </Card>
+  );
+};
 
 export default React.memo(ContributeCard);

--- a/src/mocks/skillEvaluationMocks.ts
+++ b/src/mocks/skillEvaluationMocks.ts
@@ -1,0 +1,159 @@
+/**
+ * DEV-ONLY mock evaluation results for previewing the Assessment tab UI.
+ * Remove this file when the backend returns real evaluation data.
+ */
+import { SkillEvaluationResult } from '@/types/skillEvaluation';
+
+const MOCK_EVAL_RESULTS: Record<string, SkillEvaluationResult> = {
+  'appinsights-instrumentation': {
+    skillName: 'appinsights-instrumentation',
+    status: 'fail',
+    overallScore: 3.8,
+    maxScore: 5,
+    evaluationConfigurationName: 'default',
+    updatedOn: '2026-04-15T10:30:00Z',
+    structuralChecks: {
+      status: 'pass',
+      passed: 5,
+      total: 5,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'frontmatter-present', status: 'pass', message: 'Valid YAML frontmatter found' },
+        { name: 'has-name', status: 'pass', message: 'Skill name declared' },
+        { name: 'has-description', status: 'pass', message: 'Description field present' },
+        { name: 'body-not-empty', status: 'pass', message: 'Body contains meaningful content' },
+        { name: 'has-functions', status: 'pass', message: 'At least one function defined' },
+      ],
+    },
+    schemaValidation: {
+      status: 'pass',
+      passed: 4,
+      total: 4,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'has-instructions-section', status: 'pass', message: 'Instructions section found' },
+        { name: 'has-examples-section', status: 'pass', message: 'Examples section present' },
+        { name: 'has-error-handling-section', status: 'pass', message: 'Error handling documented' },
+        { name: 'valid-schema', status: 'pass', message: 'Schema validates correctly' },
+      ],
+    },
+    qualityAssessment: {
+      status: 'fail',
+      passed: 3,
+      total: 5,
+      weightedScore: 3.8,
+      maxWeightedScore: 5,
+      scores: [
+        { name: 'instruction-clarity', score: 4.2, maxScore: 5, passed: true, reasoning: 'Instructions are clear and well-structured with good examples.' },
+        { name: 'help-completeness', score: 2.8, maxScore: 5, passed: false, reasoning: 'The guide relies heavily on linked files rather than inline content, and lacks end-to-end walkthroughs.' },
+        { name: 'safety-guidance', score: 4.5, maxScore: 5, passed: true, reasoning: 'Good coverage of security practices and data sensitivity.' },
+        { name: 'error-handling', score: 3.5, maxScore: 5, passed: false, reasoning: 'Basic error handling documented but missing common failure scenarios.' },
+        { name: 'usage-examples', score: 4.0, maxScore: 5, passed: true, reasoning: 'Solid examples provided for common use cases.' },
+      ],
+    },
+  },
+  'azure-functions-guidance': {
+    skillName: 'azure-functions-guidance',
+    status: 'pass',
+    overallScore: 4.5,
+    maxScore: 5,
+    evaluationConfigurationName: 'default',
+    updatedOn: '2026-04-14T08:15:00Z',
+    structuralChecks: {
+      status: 'pass',
+      passed: 5,
+      total: 5,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'frontmatter-present', status: 'pass', message: 'Valid YAML frontmatter found' },
+        { name: 'has-name', status: 'pass', message: 'Skill name declared' },
+        { name: 'has-description', status: 'pass', message: 'Description field present' },
+        { name: 'body-not-empty', status: 'pass', message: 'Body contains meaningful content' },
+        { name: 'has-functions', status: 'pass', message: 'Functions well-defined' },
+      ],
+    },
+    schemaValidation: {
+      status: 'pass',
+      passed: 4,
+      total: 4,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'has-instructions-section', status: 'pass', message: 'Instructions section found' },
+        { name: 'has-examples-section', status: 'pass', message: 'Examples section present' },
+        { name: 'has-error-handling-section', status: 'pass', message: 'Error handling documented' },
+        { name: 'valid-schema', status: 'pass', message: 'Schema validates correctly' },
+      ],
+    },
+    qualityAssessment: {
+      status: 'pass',
+      passed: 5,
+      total: 5,
+      weightedScore: 4.5,
+      maxWeightedScore: 5,
+      scores: [
+        { name: 'instruction-clarity', score: 4.8, maxScore: 5, passed: true, reasoning: 'Exceptionally clear step-by-step instructions.' },
+        { name: 'help-completeness', score: 4.2, maxScore: 5, passed: true, reasoning: 'Comprehensive coverage including edge cases.' },
+        { name: 'safety-guidance', score: 4.5, maxScore: 5, passed: true, reasoning: 'Thorough security and best practices guidance.' },
+        { name: 'error-handling', score: 4.3, maxScore: 5, passed: true, reasoning: 'Detailed error handling for all common scenarios.' },
+        { name: 'usage-examples', score: 4.7, maxScore: 5, passed: true, reasoning: 'Rich examples with real-world scenarios.' },
+      ],
+    },
+  },
+  'cosmos-db-patterns': {
+    skillName: 'cosmos-db-patterns',
+    status: 'fail',
+    overallScore: 2.8,
+    maxScore: 5,
+    evaluationConfigurationName: 'default',
+    updatedOn: '2026-04-13T14:45:00Z',
+    structuralChecks: {
+      status: 'pass',
+      passed: 4,
+      total: 5,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'frontmatter-present', status: 'pass', message: 'Valid YAML frontmatter found' },
+        { name: 'has-name', status: 'pass', message: 'Skill name declared' },
+        { name: 'has-description', status: 'pass', message: 'Description field present' },
+        { name: 'body-not-empty', status: 'pass', message: 'Body contains meaningful content' },
+        { name: 'has-functions', status: 'fail', message: 'No functions defined in skill manifest' },
+      ],
+    },
+    schemaValidation: {
+      status: 'fail',
+      passed: 2,
+      total: 4,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'has-instructions-section', status: 'pass', message: 'Instructions section found' },
+        { name: 'has-examples-section', status: 'fail', message: 'No examples section found' },
+        { name: 'has-error-handling-section', status: 'fail', message: 'Missing error handling section' },
+        { name: 'valid-schema', status: 'pass', message: 'Schema validates correctly' },
+      ],
+    },
+    qualityAssessment: {
+      status: 'fail',
+      passed: 1,
+      total: 5,
+      weightedScore: 2.8,
+      maxWeightedScore: 5,
+      scores: [
+        { name: 'instruction-clarity', score: 3.2, maxScore: 5, passed: false, reasoning: 'Instructions lack detail and assume significant prior knowledge.' },
+        { name: 'help-completeness', score: 2.0, maxScore: 5, passed: false, reasoning: 'Very incomplete — missing most common usage patterns.' },
+        { name: 'safety-guidance', score: 3.5, maxScore: 5, passed: false, reasoning: 'Minimal security guidance for a data-focused skill.' },
+        { name: 'error-handling', score: 2.3, maxScore: 5, passed: false, reasoning: 'Almost no error handling documentation.' },
+        { name: 'usage-examples', score: 3.0, maxScore: 5, passed: false, reasoning: 'Only one basic example, no real-world scenarios.' },
+      ],
+    },
+  },
+};
+
+export function getMockEvalResult(skillName: string): SkillEvaluationResult | undefined {
+  return MOCK_EVAL_RESULTS[skillName];
+}


### PR DESCRIPTION
- Replace custom <a> + SCSS cards with [Fluent UI v9 Card](https://storybooks.fluentui.dev/react/?path=/docs/components-card-card--docs), CardHeader, Text
- Use makeStyles + design tokens instead of SCSS modules
- Enable proper Fluent hover/focus behavior via focusMode
- Fix typography: header size={400} (Body1Strong), description size={300} (Body1)
- Add shadow8 elevation for card definition on white backgrounds
- Improve accessibility: ARIA roles, keyboard focus ring, tab navigation
- Maintain click navigation via onClick handlers
- Preserve ctrl/cmd+click to open in new tab

