### PR TITLE
fix: Add Documentation + Test console tabs for MCP assets

### DIFF
--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -333,11 +333,11 @@ export const ApiDetailPage: React.FC = () => {
       {api.data && selectedTab === 'documentation' && (
         isMcp ? (
           <>
-            {api.data.description && !api.data.description.startsWith(api.data.summary || '') && (
+            {api.data.description && api.data.description !== api.data.summary && (
               <MarkdownRenderer markdown={api.data.description} />
             )}
             <ApiAdditionalInfo api={api.data} />
-            {(!api.data.description || api.data.description.startsWith(api.data.summary || '')) && !hasAdditionalInfo && (
+            {(!api.data.description || api.data.description === api.data.summary) && !hasAdditionalInfo && (
               <EmptyStateMessage>No documentation available for this MCP server.</EmptyStateMessage>
             )}
           </>

--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Button, Dropdown, Link, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Option, SplitButton, Spinner, Tab, TabList } from '@fluentui/react-components';
-import { ArrowDownloadRegular, DocumentRegular, ListRegular } from '@fluentui/react-icons';
+import { ArrowDownloadRegular, DocumentRegular, ListRegular, WindowConsoleRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useServer } from '@/hooks/useServer';
 import { kindToResourceType, ApiDefinitionId } from '@/types/apiDefinition';
@@ -18,6 +18,7 @@ import { useApiDefinitions } from '@/hooks/useApiDefinitions';
 import ApiSpecPageLayout from '@/pages/ApiSpec/ApiSpecPageLayout';
 import McpSpecPage from '@/pages/ApiSpec/McpSpecPage';
 import EmptyStateMessage from '@/components/EmptyStateMessage';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
 import VsCodeLogo from '@/assets/vsCodeLogo.svg';
 
 export const ApiDetailPage: React.FC = () => {
@@ -224,7 +225,8 @@ export const ApiDetailPage: React.FC = () => {
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
           <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
-          {hasAdditionalInfo && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
+          {isMcp && <Tab icon={<WindowConsoleRegular />} value="testconsole">Test console</Tab>}
+          {!isMcp && hasAdditionalInfo && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
         </TabList>
       }
       selector={
@@ -328,7 +330,20 @@ export const ApiDetailPage: React.FC = () => {
       emptyMessage={!api.isLoading && !api.isError && !api.data ? 'The specified API does not exist.' : undefined}
       sidebar={undefined}
     >
-      {api.data && selectedTab === 'documentation' && renderDocumentation()}
+      {api.data && selectedTab === 'documentation' && (
+        isMcp ? (
+          <>
+            {api.data.description && !api.data.description.startsWith(api.data.summary || '') && (
+              <MarkdownRenderer markdown={api.data.description} />
+            )}
+            <ApiAdditionalInfo api={api.data} />
+            {(!api.data.description || api.data.description.startsWith(api.data.summary || '')) && !hasAdditionalInfo && (
+              <EmptyStateMessage>No documentation available for this MCP server.</EmptyStateMessage>
+            )}
+          </>
+        ) : renderDocumentation()
+      )}
+      {api.data && selectedTab === 'testconsole' && isMcp && renderDocumentation()}
       {api.data && selectedTab === 'properties' && (
         <ApiAdditionalInfo api={api.data} />
       )}


### PR DESCRIPTION
## Problem
MCP asset detail pages only show a single 'Documentation' tab that renders the MCP inspector (tools list, run tool). When the MCP server has an auth error, users see 'Failed to connect to the MCP server' with no other useful information on the page.

<img width="1166" height="508" alt="Screenshot 2026-04-30 at 1 33 32 PM" src="https://github.com/user-attachments/assets/899f9e8b-3973-43d6-8817-737ebfd52464" />


<img width="1121" height="678" alt="Screenshot 2026-04-30 at 1 33 45 PM" src="https://github.com/user-attachments/assets/a085abc5-abb2-4024-a9bc-02adab19b92a" />



Related incident: 787076576


## Solution
Split the MCP detail page into two tabs:
- **Documentation** (default tab): shows the asset's description (rendered as markdown), contacts, external docs, and custom properties
- **Test console**: the MCP inspector with tools list, run tool, and endpoint

Only affects MCP asset type. Deduplicates description when it matches the summary.