### PR TITLE
fix: Dark mode contrast and layout issues

### DIFF
--- a/src/experiences/ApiOperationDetails/ApiOperationDetails.module.scss
+++ b/src/experiences/ApiOperationDetails/ApiOperationDetails.module.scss
@@ -16,6 +16,7 @@
   
   .infoPanel {
     max-width: 100%;
+    color: var(--colorNeutralForeground1);
 
     .infoPanelContent {
       display: flex;

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -17,10 +17,10 @@ body {
 .app-root {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  background: transparent !important;
+  min-height: 100vh;
+  background: var(--colorNeutralBackground1);
 
-  > main {
+  main {
     display: flex;
     flex: 1;
 
@@ -90,4 +90,83 @@ button {
   color: inherit;
   font: inherit;
   cursor: pointer;
+}
+
+// Dark mode overrides for api-docs-ui hardcoded light colors
+// These components use #f5f5f5, #ebebeb, #f3f2f1 instead of Fluent tokens
+[class*="_infoPanel_"] {
+  border-color: var(--colorNeutralStroke1) !important;
+
+  [class*="_title_"] {
+    background-color: var(--colorNeutralBackground3) !important;
+    color: var(--colorNeutralForeground1) !important;
+  }
+
+  [class*="_content_"] {
+    color: var(--colorNeutralForeground1) !important;
+  }
+}
+
+[class*="_testConsolePanel_"] {
+  border-color: var(--colorNeutralStroke1) !important;
+
+  [class*="_header_"] {
+    background-color: var(--colorNeutralBackground3) !important;
+    color: var(--colorNeutralForeground1) !important;
+  }
+}
+
+[class*="_operation_"][class*="_isSelected_"] {
+  background-color: var(--colorNeutralBackground3) !important;
+  color: var(--colorNeutralForeground1) !important;
+}
+
+[class*="_operation_"]:hover {
+  background-color: var(--colorNeutralBackground2) !important;
+}
+
+[class*="_example_"] {
+  background: var(--colorNeutralBackground3) !important;
+  color: var(--colorNeutralForeground1) !important;
+}
+
+// Fix Prism.js code blocks — hardcoded light colors and text-shadow
+code[class*="language-"],
+pre[class*="language-"] {
+  color: var(--colorNeutralForeground1) !important;
+  text-shadow: none !important;
+  background: none !important;
+}
+
+pre[class*="language-"],
+:not(pre) > code[class*="language-"] {
+  background: var(--colorNeutralBackground3) !important;
+}
+
+// Inline code in markdown
+code {
+  color: var(--colorNeutralForeground1);
+  background: var(--colorNeutralBackground3);
+  text-shadow: none;
+}
+
+// Fix hyperlink visibility in dark mode
+a {
+  color: var(--colorBrandForeground1);
+}
+
+// Fix API operation method colors for dark mode contrast
+[class*="_apiOperationMethod_"] {
+  &[class*="_get_"] {
+    color: var(--colorPaletteGreenForeground1) !important;
+  }
+  &[class*="_post_"] {
+    color: var(--colorBrandForeground1) !important;
+  }
+  &[class*="_delete_"] {
+    color: var(--colorPaletteRedForeground1) !important;
+  }
+  &[class*="_put_"] {
+    color: var(--colorPaletteBerryForeground1) !important;
+  }
 }


### PR DESCRIPTION
## Problem
Multiple dark mode issues in the APIC Dev Portal:
- Page background cuts off to white when scrolling past viewport height
- Footer floats high on pages with little content
- `api-docs-ui` library uses hardcoded light colors (#f5f5f5, #ebebeb, #f3f2f1) that don't adapt to dark mode
- Prism.js code blocks have light text-shadow that creates ghosting on dark backgrounds
- Hyperlinks nearly invisible in dark mode
- API method labels (GET/POST/DELETE/PUT) use hardcoded colors with poor dark mode contrast

<img width="1714" height="894" alt="Screenshot 2026-04-30 at 1 55 13 PM" src="https://github.com/user-attachments/assets/0648b94c-951f-4648-b93a-afb616f4396a" />
<img width="1705" height="907" alt="Screenshot 2026-04-30 at 1 55 21 PM" src="https://github.com/user-attachments/assets/de7fef15-88f7-467d-9051-1432f2f67303" />
<img width="1812" height="708" alt="image (64)" src="https://github.com/user-attachments/assets/9fc5fd66-e6f4-4480-bc4f-8fc2b55c63a2" />



## Solution
All fixes use **Fluent 2 design tokens** so they adapt automatically to light/dark themes:

- **Footer positioning:** `min-height: 100vh` on `.app-root` pushes footer to bottom
- **api-docs-ui overrides:** InfoPanel, TestConsolePanel, operation list items → `colorNeutralBackground3`, `colorNeutralForeground1`
- **Code blocks:** removed `text-shadow`, background → `colorNeutralBackground3`
- **Links:** → `colorBrandForeground1`
- **API methods:** GET → `colorPaletteGreenForeground1`, POST → `colorBrandForeground1`, DELETE → `colorPaletteRedForeground1`, PUT → `colorPaletteBerryForeground1`

## Files changed
- `src/globals.scss` — background, layout, and dark mode token overrides
- `src/experiences/ApiOperationDetails/ApiOperationDetails.module.scss` — infoPanel color token