### PR TITLE
fix: Restore VS Code button to white with icon

### DIFF
--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -335,8 +335,7 @@ export const ApiDetailPage: React.FC = () => {
         hasInstall ? (
           <HeaderActions showExtensionHint>
             <Button
-              appearance="primary"
-              icon={<ArrowDownloadRegular />}
+              icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
               onClick={hasMcpInstall ? () => handleMcpInstall() : handleSkillInstall}
             >
               Install in VS Code


### PR DESCRIPTION
Reverts the Install in VS Code button from blue primary appearance back to default (white) with the VS Code logo icon. The button was accidentally changed to primary blue in PR #111.

---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*