### PR TITLE
feat: add agent UI (filter, list badge, detail page with definition)

### DIFF
--- a/docs/superpowers/plans/2026-05-07-agent-ui.md
+++ b/docs/superpowers/plans/2026-05-07-agent-ui.md
@@ -1,0 +1,898 @@
+# Agent UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add agent filtering, list indication, and a Skill-style detail page (with markdown definition tab) for APIs of `kind: "agent"`.
+
+**Architecture:** New `AgentInfo` page modeled on `SkillInfo` using `DetailPageLayout`. New service methods/hooks fetch agent versions and the markdown `definition` artifact. Replaces the existing `/agents/:name` chat route. Filter pill in `CategoryPills` is enabled.
+
+**Tech Stack:** React 18, TypeScript, Fluent UI v9 (`@fluentui/react-components`), TanStack Query 5, Recoil, Vite, react-markdown.
+
+**Verification:** No test framework is configured in this project (`package.json` scripts are `start`, `build`, `eslint`, `stylelint`, `lint`). Verification per task is `npm run lint` and `npm run build` (full TS type-check). Manual smoke test at end.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-agent-ui-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/types/agent.ts` — `AgentVersion`, `AgentArtifact` types
+- `src/hooks/useAgentVersions.ts`
+- `src/hooks/useAgentDefinition.ts`
+- `src/experiences/AgentDefinition/AgentDefinition.tsx` — version dropdown + markdown render + download button
+- `src/experiences/AgentDefinition/AgentDefinition.module.scss`
+- `src/experiences/AgentDefinition/index.ts`
+- `src/pages/AgentInfo/AgentInfo.tsx` — main detail page
+- `src/pages/AgentInfo/AgentInfo.module.scss`
+- `src/pages/AgentInfo/index.ts`
+
+**Modify:**
+- `src/types/services/IApiService.ts` — add 3 agent method signatures
+- `src/services/ApiService.ts` — implement the 3 methods
+- `src/services/HttpService.ts` — add `getText` helper
+- `src/services/LocationsService.ts` — add `getAgentInfoUrl`
+- `src/constants/QueryKeys.ts` — add `AgentVersions`, `AgentDefinition`
+- `src/App.tsx` — replace `<AgentChat />` route with `<AgentInfo />`
+- `src/experiences/CategoryPills/CategoryPills.tsx` — uncomment Agents pill
+- `src/experiences/ApiList/ApiList.tsx` — link agents to info page
+- `src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx` — link agents to info page
+- `src/pages/PluginInfo/PluginInfo.tsx` — link `agent` kind to info page
+
+---
+
+## Task 1: Add agent types
+
+**Files:**
+- Create: `src/types/agent.ts`
+
+- [ ] **Step 1: Create the types file**
+
+Create `src/types/agent.ts` with:
+
+```ts
+/**
+ * Type definitions for agent assets in Azure API Center.
+ *
+ * APIs of kind "agent" expose versioned definitions through dedicated
+ * endpoints under /agents/{name}. The definition artifact is markdown.
+ */
+
+export interface AgentVersion {
+  name: string;
+  title?: string;
+  lifecycleStage?: string;
+}
+
+export interface AgentArtifact {
+  name: string;
+  contentType?: string;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run build`
+Expected: succeeds (no usage yet — type file only).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/agent.ts
+git commit -m "feat(types): add AgentVersion and AgentArtifact types"
+```
+
+---
+
+## Task 2: Add `HttpService.getText` helper
+
+The agent definition `/download` endpoint returns markdown text, not JSON. The existing `HttpService.get` calls `response.json()`. Add a sibling `getText` method that returns the response body as text and uses the same workspace prefix and auth handling.
+
+**Files:**
+- Modify: `src/services/HttpService.ts`
+
+- [ ] **Step 1: Add `getText` to `HttpService`**
+
+In `src/services/HttpService.ts`, locate the `export const HttpService = {` block. After the existing `getOptional<T>` method (around line 100+), add a new method. Read the file first to find the exact insertion point — add `getText` right before the closing `};` of the `HttpService` object literal.
+
+Append (within the `HttpService` object):
+
+```ts
+  /** GET that returns the raw response body as text. Uses the same auth/workspace logic as `get`. */
+  async getText(endpoint: string, options?: RequestOptions): Promise<string | undefined> {
+    const { AuthService } = getRecoil(appServicesAtom);
+    const config = getRecoil(configAtom);
+    const accessToken = await AuthService.getAccessToken();
+
+    const init: RequestInit = {
+      method: 'GET',
+      headers: new Headers({ Accept: 'text/plain, text/markdown, */*' }),
+    };
+
+    if (accessToken) {
+      (init.headers as Headers).append('Authorization', 'Bearer ' + accessToken);
+    }
+
+    let baseUrl = `https://${config.dataApiHostName}`;
+    if (!options?.skipWorkspacePrefix && !config.dataApiHostName.includes('/workspaces/default')) {
+      baseUrl += '/workspaces/default';
+    }
+
+    const response = await fetch(`${baseUrl}${endpoint}`, init);
+
+    if (response.status === 404) return undefined;
+    if (response.status === 401 || response.status === 403) {
+      if (accessToken) {
+        setRecoil(isAccessDeniedAtom, true);
+        return undefined;
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} fetching ${endpoint}`);
+    }
+
+    return await response.text();
+  },
+```
+
+Make sure the method is placed inside the existing object literal (no other syntax changes needed — `getRecoil`, `setRecoil`, `appServicesAtom`, `configAtom`, `isAccessDeniedAtom` are already imported at the top of the file).
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/HttpService.ts
+git commit -m "feat(http): add HttpService.getText for raw text endpoints"
+```
+
+---
+
+## Task 3: Add agent methods to `IApiService` interface
+
+**Files:**
+- Modify: `src/types/services/IApiService.ts`
+
+- [ ] **Step 1: Add the import and three method signatures**
+
+At the top of `src/types/services/IApiService.ts`, add the import alongside the existing imports:
+
+```ts
+import { AgentVersion } from '@/types/agent';
+```
+
+Inside the `IApiService` interface, append three method signatures (right before the closing `}`):
+
+```ts
+  getAgentVersions(agentName: string): Promise<AgentVersion[]>;
+  getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined>;
+  getAgentDefinitionDownloadPath(agentName: string, versionName: string): string;
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: FAILS — `ApiService` does not yet implement the new methods. This confirms the interface is being checked.
+
+- [ ] **Step 3: Implement the three methods on `ApiService`**
+
+In `src/services/ApiService.ts`, add the import at the top:
+
+```ts
+import { AgentVersion } from '@/types/agent';
+```
+
+Inside the `ApiService` object (right before the closing `};`), add:
+
+```ts
+  async getAgentVersions(agentName: string): Promise<AgentVersion[]> {
+    const response = await HttpService.get<{ value: AgentVersion[] }>(
+      `/agents/${encodeURIComponent(agentName)}/versions?$top=${DEFAULT_PAGE_SIZE}`
+    );
+    return response?.value || [];
+  },
+
+  async getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined> {
+    return await HttpService.getText(
+      `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
+    );
+  },
+
+  getAgentDefinitionDownloadPath(agentName: string, versionName: string): string {
+    return `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`;
+  },
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/services/IApiService.ts src/services/ApiService.ts
+git commit -m "feat(api-service): add agent versions and definition methods"
+```
+
+---
+
+## Task 4: Add `getAgentInfoUrl` to `LocationsService`
+
+**Files:**
+- Modify: `src/services/LocationsService.ts`
+
+- [ ] **Step 1: Add the method**
+
+In `src/services/LocationsService.ts`, inside the `LocationsService` object, add a new method right after `getAgentChatUrl`:
+
+```ts
+  getAgentInfoUrl(name: string): string {
+    return `/agents/${name}`;
+  },
+```
+
+`getAgentChatUrl` stays exactly as it is (returns the same path). Both methods returning the same URL is intentional — the playground route is removed in Task 8 but the method is left in place to avoid breaking imports we miss.
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/LocationsService.ts
+git commit -m "feat(locations): add getAgentInfoUrl"
+```
+
+---
+
+## Task 5: Add agent query keys
+
+**Files:**
+- Modify: `src/constants/QueryKeys.ts`
+
+- [ ] **Step 1: Add two enum values**
+
+In `src/constants/QueryKeys.ts`, add two new values to the enum (alphabetic placement near the top is fine):
+
+```ts
+  AgentVersions = 'AgentVersions',
+  AgentDefinition = 'AgentDefinition',
+```
+
+Final file:
+
+```ts
+export enum QueryKeys {
+  Apis = 'Apis',
+  Api = 'Api',
+  AgentVersions = 'AgentVersions',
+  AgentDefinition = 'AgentDefinition',
+  Server = 'Server',
+  ApiVersions = 'ApiVersions',
+  ApiDefinitions = 'ApiDefinitions',
+  ApiDefinition = 'ApiDefinition',
+  ApiDeployments = 'ApiDeployments',
+  ApiDeploymentEnvironment = 'ApiDeploymentEnvironment',
+  ApiSpec = 'ApiSpec',
+  ApiSpecUrl = 'ApiSpecUrl',
+  ApiAuthScheme = 'ApiAuthScheme',
+  ApiAuthSchemeOptions = 'ApiAuthSchemeOptions',
+  HttpTestMutation = 'HttpTestMutation',
+  MetadataSchemas = 'MetadataSchemas',
+  Plugin = 'Plugin',
+  LanguageModel = 'LanguageModel',
+  SkillEvaluationResult = 'SkillEvaluationResult',
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/constants/QueryKeys.ts
+git commit -m "feat(query-keys): add agent versions and definition keys"
+```
+
+---
+
+## Task 6: Add `useAgentVersions` hook
+
+**Files:**
+- Create: `src/hooks/useAgentVersions.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `src/hooks/useAgentVersions.ts`:
+
+```ts
+import { useRecoilValue } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
+import { AgentVersion } from '@/types/agent';
+import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
+import { useApiService } from '@/hooks/useApiService';
+import { QueryKeys } from '@/constants/QueryKeys';
+
+export function useAgentVersions(agentName?: string) {
+  const ApiService = useApiService();
+  const isAuthenticated = useRecoilValue(isAuthenticatedAtom);
+
+  return useQuery<AgentVersion[]>({
+    queryKey: [QueryKeys.AgentVersions, agentName],
+    queryFn: () => ApiService.getAgentVersions(agentName!),
+    staleTime: Infinity,
+    enabled: Boolean(isAuthenticated && agentName),
+  });
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useAgentVersions.ts
+git commit -m "feat(hooks): add useAgentVersions"
+```
+
+---
+
+## Task 7: Add `useAgentDefinition` hook
+
+**Files:**
+- Create: `src/hooks/useAgentDefinition.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `src/hooks/useAgentDefinition.ts`:
+
+```ts
+import { useRecoilValue } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
+import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
+import { useApiService } from '@/hooks/useApiService';
+import { QueryKeys } from '@/constants/QueryKeys';
+
+export function useAgentDefinition(agentName?: string, versionName?: string) {
+  const ApiService = useApiService();
+  const isAuthenticated = useRecoilValue(isAuthenticatedAtom);
+
+  return useQuery<string | undefined>({
+    queryKey: [QueryKeys.AgentDefinition, agentName, versionName],
+    queryFn: () => ApiService.getAgentDefinition(agentName!, versionName!),
+    staleTime: Infinity,
+    enabled: Boolean(isAuthenticated && agentName && versionName),
+  });
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useAgentDefinition.ts
+git commit -m "feat(hooks): add useAgentDefinition"
+```
+
+---
+
+## Task 8: Build the `AgentDefinition` experience component
+
+This component is the Definition tab body: a version dropdown, the rendered markdown, and a Download button. The download is performed by fetching the same endpoint via `ApiService` and triggering a browser download via a temporary blob URL (auth is required, so a plain anchor `href` won't work).
+
+**Files:**
+- Create: `src/experiences/AgentDefinition/AgentDefinition.tsx`
+- Create: `src/experiences/AgentDefinition/AgentDefinition.module.scss`
+- Create: `src/experiences/AgentDefinition/index.ts`
+
+- [ ] **Step 1: Create the SCSS module**
+
+Create `src/experiences/AgentDefinition/AgentDefinition.module.scss`:
+
+```scss
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.versionSelect {
+  min-width: 200px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.errorBar {
+  margin-bottom: 8px;
+}
+```
+
+- [ ] **Step 2: Create the index file**
+
+Create `src/experiences/AgentDefinition/index.ts`:
+
+```ts
+export { AgentDefinition } from './AgentDefinition';
+export { default } from './AgentDefinition';
+```
+
+- [ ] **Step 3: Create the component**
+
+Create `src/experiences/AgentDefinition/AgentDefinition.tsx`:
+
+```tsx
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Dropdown,
+  MessageBar,
+  MessageBarBody,
+  Option,
+  Spinner,
+} from '@fluentui/react-components';
+import { ArrowDownloadRegular } from '@fluentui/react-icons';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
+import { useAgentVersions } from '@/hooks/useAgentVersions';
+import { useAgentDefinition } from '@/hooks/useAgentDefinition';
+import styles from './AgentDefinition.module.scss';
+
+interface Props {
+  agentName: string;
+}
+
+export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
+  const versions = useAgentVersions(agentName);
+  const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
+
+  // Auto-select the first version once versions load.
+  useEffect(() => {
+    if (!selectedVersion && versions.data && versions.data.length > 0) {
+      setSelectedVersion(versions.data[0].name);
+    }
+  }, [versions.data, selectedVersion]);
+
+  const definition = useAgentDefinition(agentName, selectedVersion);
+
+  const handleVersionChange= useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>(
+    (_, data) => {
+      const next = data.optionValue ?? data.selectedOptions[0];
+      if (next) setSelectedVersion(next);
+    },
+    []
+  );
+
+  const handleDownload = useCallback(async () => {
+    if (!selectedVersion || !definition.data) return;
+    const blob = new Blob([definition.data], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    try {
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${agentName}-${selectedVersion}-definition.md`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } finally {
+      // Defer revoke so the click is processed first.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+  }, [agentName, selectedVersion, definition.data]);
+
+  const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
+  const selectedTitle = useMemo(
+    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? '',
+    [versionOptions, selectedVersion]
+  );
+
+  if (versions.isLoading) {
+    return <Spinner size="small" label="Loading versions..." />;
+  }
+
+  if (versions.isError) {
+    return (
+      <MessageBar intent="error" className={styles.errorBar}>
+        <MessageBarBody>Failed to load agent versions.</MessageBarBody>
+      </MessageBar>
+    );
+  }
+
+  if (!versionOptions.length) {
+    return <EmptyStateMessage>No definition available for this agent.</EmptyStateMessage>;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <Dropdown
+          className={styles.versionSelect}
+          aria-label="Agent version"
+          value={selectedTitle}
+          selectedOptions={selectedVersion ? [selectedVersion] : []}
+          onOptionSelect={handleVersionChange}
+        >
+          {versionOptions.map((v) => (
+            <Option key={v.name} value={v.name} text={v.title ?? v.name}>
+              {v.title ?? v.name}
+            </Option>
+          ))}
+        </Dropdown>
+        <div className={styles.spacer} />
+        <Button
+          icon={<ArrowDownloadRegular />}
+          onClick={handleDownload}
+          disabled={!definition.data || definition.isLoading}
+        >
+          Download
+        </Button>
+      </div>
+
+      {definition.isLoading && <Spinner size="small" label="Loading definition..." />}
+
+      {definition.isError && (
+        <MessageBar intent="error" className={styles.errorBar}>
+          <MessageBarBody>Failed to load the agent definition.</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {!definition.isLoading && !definition.isError && (
+        definition.data
+          ? <MarkdownRenderer markdown={definition.data} />
+          : <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(AgentDefinition);
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 5: Lint the new files**
+
+Run: `npm run lint`
+Expected: no errors related to the new files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/experiences/AgentDefinition
+git commit -m "feat(agent-definition): version selector with markdown render and download"
+```
+
+---
+
+## Task 9: Build the `AgentInfo` page
+
+Mirrors `SkillInfo`. Uses `DetailPageLayout` with three tabs.
+
+**Files:**
+- Create: `src/pages/AgentInfo/AgentInfo.tsx`
+- Create: `src/pages/AgentInfo/AgentInfo.module.scss`
+- Create: `src/pages/AgentInfo/index.ts`
+
+- [ ] **Step 1: Create the SCSS module (empty placeholder)**
+
+Create `src/pages/AgentInfo/AgentInfo.module.scss`:
+
+```scss
+/* Page-specific styles for AgentInfo. Currently relies on DetailPageLayout. */
+.placeholder {
+  display: none;
+}
+```
+
+(stylelint requires at least one rule; the placeholder is intentional and unused.)
+
+- [ ] **Step 2: Create the index file**
+
+Create `src/pages/AgentInfo/index.ts`:
+
+```ts
+export { AgentInfo } from './AgentInfo';
+export { default } from './AgentInfo';
+```
+
+- [ ] **Step 3: Create the page**
+
+Create `src/pages/AgentInfo/AgentInfo.tsx`:
+
+```tsx
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Badge, Tab, TabList } from '@fluentui/react-components';
+import { CodeRegular, DocumentRegular } from '@fluentui/react-icons';
+import { useApi } from '@/hooks/useApi';
+import { setDocumentTitle } from '@/utils/dom';
+import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import CustomMetadata from '@/components/CustomMetadata';
+import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
+import { AgentDefinition } from '@/experiences/AgentDefinition';
+
+type AgentTab = 'documentation' | 'definition' | 'properties';
+
+export const AgentInfo: React.FC = () => {
+  const { name } = useParams<{ name: string }>();
+  const api = useApi(name);
+  const [selectedTab, setSelectedTab] = useState<AgentTab>('documentation');
+
+  setDocumentTitle(`Agent${api.data?.title ? ` - ${api.data.title}` : ''}`);
+
+  const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
+
+  return (
+    <DetailPageLayout
+      title={api.data?.title}
+      summary={api.data?.summary}
+      metadata={
+        <>
+          <Badge appearance="filled" color="brand" shape="circular">Agent</Badge>
+          {api.data?.lifecycleStage && (
+            <Badge appearance="tint" color="brand" shape="circular">{api.data.lifecycleStage}</Badge>
+          )}
+          {api.data?.lastUpdated && (
+            <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>
+          )}
+        </>
+      }
+      tabs={
+        <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as AgentTab)}>
+          <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
+          <Tab icon={<CodeRegular />} value="definition">Definition</Tab>
+          {hasCustomProps && <Tab value="properties">Additional properties</Tab>}
+        </TabList>
+      }
+      isLoading={api.isLoading}
+      error={api.isError ? 'Failed to load agent details. Please check your connection and try again.' : undefined}
+      onRetry={() => api.refetch()}
+      emptyMessage={!api.isLoading && !api.isError && !api.data ? 'The specified agent does not exist.' : undefined}
+      sidebar={undefined}
+    >
+      {api.data && selectedTab === 'documentation' && (
+        (api.data.description || api.data.summary)
+          ? <MarkdownRenderer markdown={(api.data.description || api.data.summary)!} />
+          : <EmptyStateMessage>No description available for this agent.</EmptyStateMessage>
+      )}
+
+      {api.data && selectedTab === 'definition' && (
+        <AgentDefinition agentName={api.data.name} />
+      )}
+
+      {api.data && selectedTab === 'properties' && hasCustomProps && (
+        <CustomMetadata value={api.data.customProperties} />
+      )}
+    </DetailPageLayout>
+  );
+};
+
+export default React.memo(AgentInfo);
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 5: Lint**
+
+Run: `npm run lint`
+Expected: no errors related to the new files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/AgentInfo
+git commit -m "feat(agent-info): Skill-style detail page with Definition tab"
+```
+
+---
+
+## Task 10: Wire the `AgentInfo` route (replace `AgentChat`)
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Replace the AgentChat route with AgentInfo**
+
+In `src/App.tsx`:
+
+1. Replace the import line `import AgentChat from '@/pages/AgentChat';` with:
+   ```ts
+   import AgentInfo from '@/pages/AgentInfo';
+   ```
+
+2. Replace the route entry:
+   ```tsx
+           {
+             path: 'agents/:name',
+             element: <AgentChat />,
+           },
+   ```
+   with:
+   ```tsx
+           {
+             path: 'agents/:name',
+             element: <AgentInfo />,
+           },
+   ```
+
+(The `AgentChat` page file remains in the tree but is no longer referenced from the router. Removing the file is out of scope.)
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: succeeds. (Unused imports inside `AgentChat.tsx` itself are fine — it's no longer reached, but the file still type-checks.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat(routing): use AgentInfo for /agents/:name (replaces AgentChat)"
+```
+
+---
+
+## Task 11: Repoint agent links to the info page
+
+Three call sites currently call `LocationsService.getAgentChatUrl(...)`. Repoint them to `getAgentInfoUrl(...)`. Both methods currently return the same URL, but using the info-named method is the correct semantics going forward.
+
+**Files:**
+- Modify: `src/experiences/ApiList/ApiList.tsx`
+- Modify: `src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx`
+- Modify: `src/pages/PluginInfo/PluginInfo.tsx`
+
+- [ ] **Step 1: Update `ApiList.tsx`**
+
+In `src/experiences/ApiList/ApiList.tsx`, change line 52:
+```ts
+      if (kind === 'agent') return LocationsService.getAgentChatUrl(api.name);
+```
+to:
+```ts
+      if (kind === 'agent') return LocationsService.getAgentInfoUrl(api.name);
+```
+
+- [ ] **Step 2: Update `ApiSearchAutoComplete.tsx`**
+
+In `src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx`, change line 19:
+```ts
+    return { to: LocationsService.getAgentChatUrl(api.name) };
+```
+to:
+```ts
+    return { to: LocationsService.getAgentInfoUrl(api.name) };
+```
+
+- [ ] **Step 3: Update `PluginInfo.tsx`**
+
+In `src/pages/PluginInfo/PluginInfo.tsx`, change line 41:
+```ts
+  if (k === 'agent') return { to: LocationsService.getAgentChatUrl(name) };
+```
+to:
+```ts
+  if (k === 'agent') return { to: LocationsService.getAgentInfoUrl(name) };
+```
+
+- [ ] **Step 4: Build + lint**
+
+Run: `npm run build && npm run lint`
+Expected: both succeed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/experiences/ApiList/ApiList.tsx src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx src/pages/PluginInfo/PluginInfo.tsx
+git commit -m "feat(links): point agent links to AgentInfo page"
+```
+
+---
+
+## Task 12: Enable the Agents pill in `CategoryPills`
+
+**Files:**
+- Modify: `src/experiences/CategoryPills/CategoryPills.tsx`
+
+- [ ] **Step 1: Uncomment the Agents pill**
+
+In `src/experiences/CategoryPills/CategoryPills.tsx`, change line 24 from:
+```ts
+  // { label: 'Agents', kindValue: 'agent', icon: <BotRegular /> },
+```
+to:
+```ts
+  { label: 'Agents', kindValue: 'agent', icon: <BotRegular /> },
+```
+
+`BotRegular` is already imported at the top of the file. Place the entry in the same position (between APIs and MCP servers) — that ordering puts higher-value categories together.
+
+- [ ] **Step 2: Build + lint**
+
+Run: `npm run build && npm run lint`
+Expected: both succeed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/experiences/CategoryPills/CategoryPills.tsx
+git commit -m "feat(category-pills): enable Agents pill"
+```
+
+---
+
+## Task 13: Final verification
+
+- [ ] **Step 1: Full build**
+
+Run: `npm run build`
+Expected: succeeds with no TypeScript errors.
+
+- [ ] **Step 2: Full lint**
+
+Run: `npm run lint`
+Expected: succeeds (eslint + stylelint, no errors).
+
+- [ ] **Step 3: Manual smoke test**
+
+Start the app: `npm start`
+
+Verify each of:
+- The **Agents** category pill is visible on the home page next to APIs / MCP servers / Plugins / Skills.
+- Clicking it filters the list to agents only (cards show the **Agent** brand badge).
+- Clicking an agent card navigates to `/agents/<name>` and renders the new `AgentInfo` page (NOT the old chat page).
+- The header shows: title, summary, **Agent** badge, lifecycleStage badge (if set), last-updated string.
+- **Documentation** tab renders the agent's description as markdown (or an empty-state message if missing).
+- **Definition** tab loads versions, shows them in the dropdown, renders the markdown definition for the selected version, and the **Download** button produces a `<name>-<version>-definition.md` file in the browser.
+- **Additional properties** tab appears only when `customProperties` is non-empty.
+- Search autocomplete: typing an agent name and clicking it lands on `/agents/<name>` (info page).
+- Plugin detail page: links from a plugin to a related agent go to the info page.
+
+- [ ] **Step 4: Verify spec coverage**
+
+Open `docs/superpowers/specs/2026-05-07-agent-ui-design.md` and confirm every "UI changes" / "Data layer" / "Routing" item is implemented. There are no remaining items.
+
+- [ ] **Step 5: No commit needed for verification**
+
+Verification is observational. If anything is broken, fix it and commit per the relevant earlier task.
+
+---
+
+## Out of Scope (do not do)
+
+- Deleting `src/pages/AgentChat/` — the directory remains; the route is just no longer registered.
+- Parsing markdown frontmatter / structured-field summary panel.
+- Any changes to `AgentChat.tsx`'s internals.
+- Changes to `src/config/apiFilters.ts` (the dropdown filter — `agent` is already there).
+- Changes to `STANDALONE_KINDS` arrays in `ApiCard.tsx` / `ApiList.tsx` — `agent` is already in them.
+- Adding tests — this codebase has no test framework configured.

--- a/docs/superpowers/specs/2026-05-07-agent-ui-design.md
+++ b/docs/superpowers/specs/2026-05-07-agent-ui-design.md
@@ -1,0 +1,193 @@
+# Agent UI — Design Spec
+
+## Problem
+
+The backend now exposes APIs of `kind: "agent"` plus a dedicated agent endpoint surface
+(`/workspaces/{ws}/agents/...`) including versions and a `definition` artifact. The
+portal needs:
+
+1. Agent filtering on the home/list page (sidebar filter + category pill).
+2. Agent indication in the API list/cards (badge).
+3. A detail page modeled after the Skill detail page, additionally surfacing the
+   markdown agent definition.
+
+The existing `AgentChat` (chat playground) page is **not** part of this work and will
+not be linked from the new UI.
+
+## Approach
+
+Mirror the existing Skill UI patterns exactly where possible. Agents are treated as a
+standalone kind (alongside `skill`, `plugin`, `mcp`, etc.). Add a new `AgentInfo` page
+that uses `DetailPageLayout`, reuses tab/badge/markdown patterns from `SkillInfo`, and
+adds a single new tab for the agent definition that fetches a markdown artifact and
+renders it with `MarkdownRenderer`.
+
+### Out of scope
+
+- Parsing the markdown (no YAML frontmatter extraction, no structured-field panel).
+- Linking to the chat playground (`AgentChat`) from the new detail page.
+- Changes to the search filter dropdown — `kind: agent` already exists in
+  `src/config/apiFilters.ts`.
+- Changes to `ApiCard` / `ApiList` badge logic — `agent` is already in
+  `STANDALONE_KINDS`.
+
+## UI changes
+
+### List page
+
+- `src/experiences/CategoryPills/CategoryPills.tsx`: uncomment the **Agents** pill
+  (label `Agents`, kind value `agent`, icon `BotRegular`). No other changes to that
+  component.
+
+### Detail page (new): `AgentInfo`
+
+Location: `src/pages/AgentInfo/AgentInfo.tsx` (+ `.module.scss`, `index.ts`).
+
+Modeled on `src/pages/SkillInfo/SkillInfo.tsx`.
+
+**Header (`DetailPageLayout` props):**
+
+- `title`: `api.data.title`
+- `summary`: `api.data.summary`
+- `metadata`:
+  - `<Badge appearance="filled" color="brand" shape="circular">Agent</Badge>`
+  - lifecycle stage badge if present
+  - "Last updated …" if present
+- `headerActions`: none.
+
+**Tabs:**
+
+1. **Documentation** (default) — `MarkdownRenderer` of
+   `api.data.description ?? api.data.summary`. Empty state if neither present
+   (same copy pattern as `SkillInfo`).
+2. **Definition** — see below.
+3. **Additional properties** — only when `customProperties` is non-empty; renders
+   `<CustomMetadata value={api.data.customProperties} />`. (Same gating as
+   `SkillInfo`.)
+
+**Definition tab:**
+
+- A version `<Dropdown>` (Fluent v9) at the top of the tab content. Sourced from
+  `useAgentVersions(name)`. Defaults to the first version returned by the API.
+- Body: `MarkdownRenderer` rendering the markdown text returned by
+  `useAgentDefinition(name, selectedVersion)`.
+- A **Download** button (next to the dropdown) that triggers the download
+  endpoint for the `definition` artifact of the selected version.
+- Loading: spinner while versions or definition are loading.
+- Error: standard error message + retry, matching existing patterns
+  (`useApi` / `useSkillEvaluationResult` style).
+- Empty: if no versions exist, render an `EmptyStateMessage`
+  (`No definition available for this agent.`).
+
+### Routing
+
+- `src/App.tsx`: add `{ path: 'agents/:name', element: <AgentInfo /> }`.
+- The existing `AgentChat` route registration **remains** unchanged for now (the
+  page is unlinked but reachable directly by URL). It can be removed later if
+  desired; that cleanup is out of scope here.
+- Update link generation everywhere agents are linked to point to the info page:
+  - `src/experiences/ApiList/ApiList.tsx` — `if (kind === 'agent') return LocationsService.getAgentInfoUrl(api.name);`
+  - `src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx` — same.
+  - `src/pages/PluginInfo/PluginInfo.tsx` line 41 — same.
+
+> Note on App.tsx routing collision: the new `AgentInfo` route at `agents/:name`
+> replaces the previous `AgentChat` registration at the same path. Drop the old
+> `<AgentChat />` route entry from `App.tsx`. The component itself stays in the
+> tree; it is simply no longer referenced from the router. (Removing the unused
+> file is optional cleanup; not in scope.)
+
+## Data layer
+
+### `LocationsService` (`src/services/LocationsService.ts`)
+
+Add:
+
+```ts
+getAgentInfoUrl(name: string): string {
+  return `/agents/${encodeURIComponent(name)}`;
+}
+```
+
+Keep `getAgentChatUrl` as-is (still returns `/agents/:name`); it is no longer
+called from production code paths but remains for any external consumers. If
+keeping both creates confusion, the implementer may collapse them into one — both
+return the same path.
+
+### Types (`src/types/agent.ts`, new)
+
+```ts
+export interface AgentVersion {
+  name: string;
+  title?: string;
+  lifecycleStage?: string;
+}
+
+export interface AgentArtifact {
+  name: string;
+  contentType?: string;
+}
+```
+
+(Reusing `ApiVersion` is acceptable if its shape matches the agent versions
+response. Implementer to verify against actual API response and choose the
+simpler option.)
+
+### `ApiService` additions (`src/services/ApiService.ts` + `IApiService`)
+
+```ts
+getAgentVersions(agentName: string): Promise<AgentVersion[]>;
+// GET /agents/{agentName}/versions
+
+getAgentDefinition(agentName: string, versionName: string): Promise<string>;
+// Fetches /agents/{agentName}/versions/{versionName}/artifacts/definition/download
+// and returns the response body as text (markdown).
+
+getAgentDefinitionDownloadUrl(agentName: string, versionName: string): string;
+// Returns the absolute URL to the /download endpoint, suitable for a Download button.
+```
+
+Implementation follows the existing `getVersions` / `getSpecification` patterns
+in `ApiService.ts`. `HttpService` is reused for auth headers.
+
+### Hooks
+
+- `src/hooks/useAgentVersions.ts` — wraps `ApiService.getAgentVersions` with
+  React Query, keyed by agent name. Mirrors `useSkillEvaluationResult` /
+  `useApi` style.
+- `src/hooks/useAgentDefinition.ts` — wraps `ApiService.getAgentDefinition`,
+  keyed by `(agentName, versionName)`, only enabled when both are truthy.
+
+### Query keys (`src/constants/QueryKeys.ts`)
+
+Add `AgentVersions`, `AgentDefinition` keys following the existing pattern.
+
+## Testing & verification
+
+- Type-check: `npm run build` (or whatever the project uses for tsc) must pass.
+- Lint: `npm run lint` must pass for changed files.
+- Manual:
+  - Filter chip "Agents" appears and filters the list to `kind: agent`.
+  - Cards for agent APIs show the **Agent** brand badge.
+  - Navigating to an agent from the list lands on the new `AgentInfo` page
+    (not the chat).
+  - Documentation tab renders markdown.
+  - Definition tab: version dropdown lists versions; selecting one renders the
+    markdown definition; Download button downloads the markdown.
+  - Additional properties tab appears only when custom props exist.
+  - Loading, empty, and error states display sensibly.
+
+If automated tests exist for `SkillInfo` or list links, mirror them for the
+agent equivalents.
+
+## Risks / open items
+
+- **Endpoint auth/CORS**: the `/download` endpoint may issue a redirect or
+  require the auth header. If a direct anchor download fails, fall back to
+  fetching via `HttpService` (with auth) and creating an object URL for the
+  download click. Implementer to verify during integration.
+- **Version response shape**: assumed compatible with `ApiVersion`. If the
+  agent versions response differs materially, define `AgentVersion` properly
+  rather than reusing.
+- **AgentChat route collision**: removing the old `<AgentChat />` route entry is
+  required. If `AgentChat` should be deleted entirely (file + i18n + tests),
+  that is a follow-up cleanup task.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Home from '@/pages/Home';
 import ApiSpec from '@/pages/ApiSpec';
 import SkillInfo from '@/pages/SkillInfo';
 import PluginInfo from '@/pages/PluginInfo';
-import AgentChat from '@/pages/AgentChat';
+import AgentInfo from '@/pages/AgentInfo';
 import ApiDetailPage from '@/pages/ApiDetailPage';
 import ModelDetailPage from '@/pages/ModelDetailPage';
 import { ModelPlayground } from '@/pages/ModelPlayground';
@@ -59,7 +59,7 @@ const App: React.FC = () => {
           },
           {
             path: 'agents/:name',
-            element: <AgentChat />,
+            element: <AgentInfo />,
           },
 
         ],

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -1,6 +1,8 @@
 export enum QueryKeys {
   Apis = 'Apis',
   Api = 'Api',
+  AgentVersions = 'AgentVersions',
+  AgentDefinition = 'AgentDefinition',
   Server = 'Server',
   ApiVersions = 'ApiVersions',
   ApiDefinitions = 'ApiDefinitions',

--- a/src/experiences/AgentDefinition/AgentDefinition.module.scss
+++ b/src/experiences/AgentDefinition/AgentDefinition.module.scss
@@ -1,0 +1,24 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.versionSelect {
+  min-width: 200px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.errorBar {
+  margin-bottom: 8px;
+}

--- a/src/experiences/AgentDefinition/AgentDefinition.module.scss
+++ b/src/experiences/AgentDefinition/AgentDefinition.module.scss
@@ -4,19 +4,55 @@
   gap: 16px;
 }
 
-.toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-}
+.markdown {
+  line-height: 1.5;
 
-.versionSelect {
-  min-width: 200px;
-}
+  :global {
+    p,
+    ul,
+    ol {
+      margin-top: 0;
+      margin-bottom: 0.5em;
+    }
 
-.spacer {
-  flex: 1;
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 1em;
+      margin-bottom: 0.4em;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.5em;
+    }
+
+    li {
+      margin-bottom: 0.15em;
+    }
+
+    code {
+      padding: 2px 6px;
+      border-radius: 4px;
+      background-color: var(--colorNeutralBackground3);
+      font-size: 0.85em;
+    }
+
+    pre {
+      padding: 12px;
+      overflow-x: auto;
+      border-radius: 6px;
+      background-color: var(--colorNeutralBackground3);
+
+      code {
+        padding: 0;
+        background: none;
+      }
+    }
+  }
 }
 
 .errorBar {

--- a/src/experiences/AgentDefinition/AgentDefinition.module.scss
+++ b/src/experiences/AgentDefinition/AgentDefinition.module.scss
@@ -22,3 +22,66 @@
 .errorBar {
   margin-bottom: 8px;
 }
+
+.frontmatterTable {
+  width: 100%;
+  margin-bottom: 16px;
+  overflow: hidden;
+  border-spacing: 0;
+  border: 1px solid var(--colorNeutralStroke2);
+  border-radius: 6px;
+
+  th,
+  td {
+    padding: 6px 13px;
+    border-top: 1px solid var(--colorNeutralStroke2);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    width: 1%;
+    background-color: var(--colorNeutralBackground2);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  tr:first-child {
+    th,
+    td {
+      border-top: none;
+    }
+  }
+
+  tr:nth-child(even) td {
+    background-color: var(--colorNeutralBackground2);
+  }
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tag {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background-color: var(--colorNeutralBackground3);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.85em;
+}
+
+.codeBlock {
+  margin: 0;
+  padding: 8px;
+  overflow-x: auto;
+  border-radius: 4px;
+  background-color: var(--colorNeutralBackground3);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.85em;
+}
+
+.emptyValue {
+  color: var(--colorNeutralForeground3);
+}

--- a/src/experiences/AgentDefinition/AgentDefinition.tsx
+++ b/src/experiences/AgentDefinition/AgentDefinition.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Dropdown, MessageBar, MessageBarBody, Option, Spinner } from '@fluentui/react-components';
+import { ArrowDownloadRegular } from '@fluentui/react-icons';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
+import { useAgentVersions } from '@/hooks/useAgentVersions';
+import { useAgentDefinition } from '@/hooks/useAgentDefinition';
+import styles from './AgentDefinition.module.scss';
+
+interface Props {
+  agentName: string;
+}
+
+export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
+  const versions = useAgentVersions(agentName);
+  const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
+
+  // Auto-select the first version once versions load.
+  useEffect(() => {
+    if (!selectedVersion && versions.data && versions.data.length > 0) {
+      setSelectedVersion(versions.data[0].name);
+    }
+  }, [versions.data, selectedVersion]);
+
+  const definition = useAgentDefinition(agentName, selectedVersion);
+
+  const handleVersionChange = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>((_, data) => {
+    const next = data.optionValue ?? data.selectedOptions[0];
+    if (next) setSelectedVersion(next);
+  }, []);
+
+  const handleDownload = useCallback(() => {
+    if (!selectedVersion || !definition.data) return;
+    const blob = new Blob([definition.data], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    try {
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${agentName}-${selectedVersion}-definition.md`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } finally {
+      // Defer revoke so the click is processed first.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+  }, [agentName, selectedVersion, definition.data]);
+
+  const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
+  const selectedTitle = useMemo(
+    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? '',
+    [versionOptions, selectedVersion]
+  );
+
+  if (versions.isLoading) {
+    return <Spinner size="small" label="Loading versions..." />;
+  }
+
+  if (versions.isError) {
+    return (
+      <MessageBar intent="error" className={styles.errorBar}>
+        <MessageBarBody>Failed to load agent versions.</MessageBarBody>
+      </MessageBar>
+    );
+  }
+
+  if (!versionOptions.length) {
+    return <EmptyStateMessage>No definition available for this agent.</EmptyStateMessage>;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <Dropdown
+          className={styles.versionSelect}
+          aria-label="Agent version"
+          value={selectedTitle}
+          selectedOptions={selectedVersion ? [selectedVersion] : []}
+          onOptionSelect={handleVersionChange}
+        >
+          {versionOptions.map((v) => (
+            <Option key={v.name} value={v.name} text={v.title ?? v.name}>
+              {v.title ?? v.name}
+            </Option>
+          ))}
+        </Dropdown>
+        <div className={styles.spacer} />
+        <Button
+          icon={<ArrowDownloadRegular />}
+          disabled={!definition.data || definition.isLoading}
+          onClick={handleDownload}
+        >
+          Download
+        </Button>
+      </div>
+
+      {definition.isLoading && <Spinner size="small" label="Loading definition..." />}
+
+      {definition.isError && (
+        <MessageBar intent="error" className={styles.errorBar}>
+          <MessageBarBody>Failed to load the agent definition.</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {!definition.isLoading &&
+        !definition.isError &&
+        (definition.data ? (
+          <MarkdownRenderer markdown={definition.data} />
+        ) : (
+          <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
+        ))}
+    </div>
+  );
+};
+
+export default React.memo(AgentDefinition);

--- a/src/experiences/AgentDefinition/AgentDefinition.tsx
+++ b/src/experiences/AgentDefinition/AgentDefinition.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Dropdown, MessageBar, MessageBarBody, Option, Spinner } from '@fluentui/react-components';
 import { ArrowDownloadRegular } from '@fluentui/react-icons';
+import * as yaml from 'yaml';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
 import { useAgentVersions } from '@/hooks/useAgentVersions';
@@ -9,6 +10,74 @@ import styles from './AgentDefinition.module.scss';
 
 interface Props {
   agentName: string;
+}
+
+const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+interface ParsedDefinition {
+  frontmatter?: Record<string, unknown>;
+  body: string;
+}
+
+function parseDefinition(markdown: string): ParsedDefinition {
+  const match = markdown.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return { body: markdown };
+  }
+
+  try {
+    const parsed = yaml.parse(match[1]);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { frontmatter: parsed as Record<string, unknown>, body: markdown.slice(match[0].length) };
+    }
+  } catch {
+    // Fall through and render the original markdown as-is.
+  }
+
+  return { body: markdown };
+}
+
+function formatFrontmatterValue(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return <span className={styles.emptyValue}>—</span>;
+  }
+  if (Array.isArray(value)) {
+    if (!value.length) return <span className={styles.emptyValue}>—</span>;
+    return (
+      <div className={styles.tagList}>
+        {value.map((item, i) => (
+          <code key={i} className={styles.tag}>
+            {typeof item === 'string' ? item : JSON.stringify(item)}
+          </code>
+        ))}
+      </div>
+    );
+  }
+  if (typeof value === 'object') {
+    return <pre className={styles.codeBlock}>{JSON.stringify(value, null, 2)}</pre>;
+  }
+  if (typeof value === 'boolean' || typeof value === 'number') {
+    return <code className={styles.tag}>{String(value)}</code>;
+  }
+  return String(value);
+}
+
+function renderFrontmatterTable(data: Record<string, unknown>): React.ReactNode {
+  const entries = Object.entries(data);
+  if (!entries.length) return null;
+
+  return (
+    <table className={styles.frontmatterTable}>
+      <tbody>
+        {entries.map(([key, value]) => (
+          <tr key={key}>
+            <th scope="row">{key}</th>
+            <td>{formatFrontmatterValue(value)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
 }
 
 export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
@@ -50,6 +119,11 @@ export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
   const selectedTitle = useMemo(
     () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? '',
     [versionOptions, selectedVersion]
+  );
+
+  const parsed = useMemo<ParsedDefinition | undefined>(
+    () => (definition.data ? parseDefinition(definition.data) : undefined),
+    [definition.data]
   );
 
   if (versions.isLoading) {
@@ -104,8 +178,15 @@ export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
 
       {!definition.isLoading &&
         !definition.isError &&
-        (definition.data ? (
-          <MarkdownRenderer markdown={definition.data} />
+        (parsed ? (
+          <>
+            {parsed.frontmatter && renderFrontmatterTable(parsed.frontmatter)}
+            {parsed.body.trim() ? (
+              <MarkdownRenderer markdown={parsed.body} />
+            ) : (
+              !parsed.frontmatter && <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
+            )}
+          </>
         ) : (
           <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
         ))}

--- a/src/experiences/AgentDefinition/AgentDefinition.tsx
+++ b/src/experiences/AgentDefinition/AgentDefinition.tsx
@@ -1,15 +1,14 @@
-import React, { useCallback, useMemo } from 'react';
-import { Button, MessageBar, MessageBarBody, Spinner } from '@fluentui/react-components';
-import { ArrowDownloadRegular } from '@fluentui/react-icons';
+import React, { useMemo } from 'react';
+import { MessageBar, MessageBarBody, Spinner } from '@fluentui/react-components';
 import * as yaml from 'yaml';
+import { UseQueryResult } from '@tanstack/react-query';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
-import { useAgentDefinition } from '@/hooks/useAgentDefinition';
 import styles from './AgentDefinition.module.scss';
 
 interface Props {
-  agentName: string;
-  versionName?: string;
+  definition: UseQueryResult<string | undefined>;
+  hasVersion: boolean;
 }
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
@@ -80,70 +79,42 @@ function renderFrontmatterTable(data: Record<string, unknown>): React.ReactNode 
   );
 }
 
-export const AgentDefinition: React.FC<Props> = ({ agentName, versionName }) => {
-  const definition = useAgentDefinition(agentName, versionName);
-
-  const handleDownload = useCallback(() => {
-    if (!versionName || !definition.data) return;
-    const blob = new Blob([definition.data], { type: 'text/markdown' });
-    const url = URL.createObjectURL(blob);
-    try {
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `${agentName}-${versionName}-definition.md`;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-    } finally {
-      // Defer revoke so the click is processed first.
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    }
-  }, [agentName, versionName, definition.data]);
-
+export const AgentDefinition: React.FC<Props> = ({ definition, hasVersion }) => {
   const parsed = useMemo<ParsedDefinition | undefined>(
     () => (definition.data ? parseDefinition(definition.data) : undefined),
     [definition.data]
   );
 
-  if (!versionName) {
+  if (!hasVersion) {
     return <EmptyStateMessage>No definition available for this agent.</EmptyStateMessage>;
+  }
+
+  if (definition.isLoading) {
+    return <Spinner size="small" label="Loading definition..." />;
+  }
+
+  if (definition.isError) {
+    return (
+      <MessageBar intent="error" className={styles.errorBar}>
+        <MessageBarBody>Failed to load the agent definition.</MessageBarBody>
+      </MessageBar>
+    );
+  }
+
+  if (!parsed) {
+    return <EmptyStateMessage>This version has no definition.</EmptyStateMessage>;
   }
 
   return (
     <div className={styles.container}>
-      <div className={styles.toolbar}>
-        <div className={styles.spacer} />
-        <Button
-          icon={<ArrowDownloadRegular />}
-          disabled={!definition.data || definition.isLoading}
-          onClick={handleDownload}
-        >
-          Download
-        </Button>
-      </div>
-
-      {definition.isLoading && <Spinner size="small" label="Loading definition..." />}
-
-      {definition.isError && (
-        <MessageBar intent="error" className={styles.errorBar}>
-          <MessageBarBody>Failed to load the agent definition.</MessageBarBody>
-        </MessageBar>
+      {parsed.frontmatter && renderFrontmatterTable(parsed.frontmatter)}
+      {parsed.body.trim() ? (
+        <div className={styles.markdown}>
+          <MarkdownRenderer markdown={parsed.body} />
+        </div>
+      ) : (
+        !parsed.frontmatter && <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
       )}
-
-      {!definition.isLoading &&
-        !definition.isError &&
-        (parsed ? (
-          <>
-            {parsed.frontmatter && renderFrontmatterTable(parsed.frontmatter)}
-            {parsed.body.trim() ? (
-              <MarkdownRenderer markdown={parsed.body} />
-            ) : (
-              !parsed.frontmatter && <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
-            )}
-          </>
-        ) : (
-          <EmptyStateMessage>This version has no definition.</EmptyStateMessage>
-        ))}
     </div>
   );
 };

--- a/src/experiences/AgentDefinition/AgentDefinition.tsx
+++ b/src/experiences/AgentDefinition/AgentDefinition.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, Dropdown, MessageBar, MessageBarBody, Option, Spinner } from '@fluentui/react-components';
+import React, { useCallback, useMemo } from 'react';
+import { Button, MessageBar, MessageBarBody, Spinner } from '@fluentui/react-components';
 import { ArrowDownloadRegular } from '@fluentui/react-icons';
 import * as yaml from 'yaml';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
-import { useAgentVersions } from '@/hooks/useAgentVersions';
 import { useAgentDefinition } from '@/hooks/useAgentDefinition';
 import styles from './AgentDefinition.module.scss';
 
 interface Props {
   agentName: string;
+  versionName?: string;
 }
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
@@ -80,32 +80,17 @@ function renderFrontmatterTable(data: Record<string, unknown>): React.ReactNode 
   );
 }
 
-export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
-  const versions = useAgentVersions(agentName);
-  const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
-
-  // Auto-select the first version once versions load.
-  useEffect(() => {
-    if (!selectedVersion && versions.data && versions.data.length > 0) {
-      setSelectedVersion(versions.data[0].name);
-    }
-  }, [versions.data, selectedVersion]);
-
-  const definition = useAgentDefinition(agentName, selectedVersion);
-
-  const handleVersionChange = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>((_, data) => {
-    const next = data.optionValue ?? data.selectedOptions[0];
-    if (next) setSelectedVersion(next);
-  }, []);
+export const AgentDefinition: React.FC<Props> = ({ agentName, versionName }) => {
+  const definition = useAgentDefinition(agentName, versionName);
 
   const handleDownload = useCallback(() => {
-    if (!selectedVersion || !definition.data) return;
+    if (!versionName || !definition.data) return;
     const blob = new Blob([definition.data], { type: 'text/markdown' });
     const url = URL.createObjectURL(blob);
     try {
       const link = document.createElement('a');
       link.href = url;
-      link.download = `${agentName}-${selectedVersion}-definition.md`;
+      link.download = `${agentName}-${versionName}-definition.md`;
       document.body.appendChild(link);
       link.click();
       link.remove();
@@ -113,51 +98,20 @@ export const AgentDefinition: React.FC<Props> = ({ agentName }) => {
       // Defer revoke so the click is processed first.
       setTimeout(() => URL.revokeObjectURL(url), 0);
     }
-  }, [agentName, selectedVersion, definition.data]);
-
-  const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
-  const selectedTitle = useMemo(
-    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? '',
-    [versionOptions, selectedVersion]
-  );
+  }, [agentName, versionName, definition.data]);
 
   const parsed = useMemo<ParsedDefinition | undefined>(
     () => (definition.data ? parseDefinition(definition.data) : undefined),
     [definition.data]
   );
 
-  if (versions.isLoading) {
-    return <Spinner size="small" label="Loading versions..." />;
-  }
-
-  if (versions.isError) {
-    return (
-      <MessageBar intent="error" className={styles.errorBar}>
-        <MessageBarBody>Failed to load agent versions.</MessageBarBody>
-      </MessageBar>
-    );
-  }
-
-  if (!versionOptions.length) {
+  if (!versionName) {
     return <EmptyStateMessage>No definition available for this agent.</EmptyStateMessage>;
   }
 
   return (
     <div className={styles.container}>
       <div className={styles.toolbar}>
-        <Dropdown
-          className={styles.versionSelect}
-          aria-label="Agent version"
-          value={selectedTitle}
-          selectedOptions={selectedVersion ? [selectedVersion] : []}
-          onOptionSelect={handleVersionChange}
-        >
-          {versionOptions.map((v) => (
-            <Option key={v.name} value={v.name} text={v.title ?? v.name}>
-              {v.title ?? v.name}
-            </Option>
-          ))}
-        </Dropdown>
         <div className={styles.spacer} />
         <Button
           icon={<ArrowDownloadRegular />}

--- a/src/experiences/AgentDefinition/index.ts
+++ b/src/experiences/AgentDefinition/index.ts
@@ -1,0 +1,2 @@
+export { AgentDefinition } from './AgentDefinition';
+export { default } from './AgentDefinition';

--- a/src/experiences/ApiDefinitionSelect/ApiDefinitionSelect.tsx
+++ b/src/experiences/ApiDefinitionSelect/ApiDefinitionSelect.tsx
@@ -8,6 +8,7 @@ import { ApiDeployment } from '@/types/apiDeployment';
 import { useApiVersions } from '@/hooks/useApiVersions';
 import { useApiDefinitions } from '@/hooks/useApiDefinitions';
 import { useApiDeployments } from '@/hooks/useApiDeployments';
+import { VersionSelect } from '@/experiences/VersionSelect';
 import styles from './ApiDefinitionSelect.module.scss';
 
 export interface ApiDefinitionSelection {
@@ -29,7 +30,6 @@ interface Props {
   onSelectionChange: (selection: ApiDefinitionSelection) => void;
 }
 
-const NO_VERSION_LABEL = "Version isn't available";
 const NO_DEFINITION_LABEL = "Definition isn't available";
 const NO_DEPLOYMENT_LABEL = "Deployment isn't available";
 
@@ -86,12 +86,12 @@ export const ApiDefinitionSelect: React.FC<Props> = ({
     onSelectionChange({ version, definition, deployment });
   }, [definition, deployment, onSelectionChange, version]);
 
-  const handleVersionSelect = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>(
-    (_, data) => {
+  const handleVersionSelect = useCallback(
+    (versionName: string) => {
       // Only reset definition when the user changes version.
       // Avoids wiping the definition that gets initialized from cached query results.
       setDefinition(undefined);
-      setVersion(apiVersions.data?.find((version) => version.name === data.selectedOptions[0]));
+      setVersion(apiVersions.data?.find((v) => v.name === versionName));
     },
     [apiVersions.data]
   );
@@ -116,26 +116,14 @@ export const ApiDefinitionSelect: React.FC<Props> = ({
       onMouseDown={(e) => e.preventDefault()}
     >
       {!hiddenSelects.includes('version') && (
-        <div className={styles.selectionDropdown}>
-          <label htmlFor="version-select">Version</label>
-
-          <Dropdown
-            id="version-select"
-            className={styles.dropdown}
-            placeholder="Select API version"
-            size={dropdownSize}
-            value={version?.title || NO_VERSION_LABEL}
-            selectedOptions={[version?.name]}
-            disabled={!apiVersions.data?.length}
-            onOptionSelect={handleVersionSelect}
-          >
-            {apiVersions.data?.map((version) => (
-              <Option key={version.name} value={version.name}>
-                {version.title || version.name}
-              </Option>
-            ))}
-          </Dropdown>
-        </div>
+        <VersionSelect
+          id="version-select"
+          versions={apiVersions.data ?? []}
+          selectedName={version?.name}
+          isInline={isInline}
+          placeholder="Select API version"
+          onChange={handleVersionSelect}
+        />
       )}
 
       {!hiddenSelects.includes('definition') && (

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -49,7 +49,7 @@ export const ApiList: React.FC = () => {
   const getApiUrl = useCallback(
     (api: ApiCardApi) => {
       const kind = (api as ApiCardApi & { type?: string }).type?.toLowerCase();
-      if (kind === 'agent') return LocationsService.getAgentChatUrl(api.name);
+      if (kind === 'agent') return LocationsService.getAgentInfoUrl(api.name);
       if (kind === 'skill') return LocationsService.getSkillInfoUrl(api.name);
       if (kind === 'plugin') return LocationsService.getPluginInfoUrl(api.name);
       if (kind === 'languagemodel') return LocationsService.getModelPlaygroundUrl(api.name);

--- a/src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx
+++ b/src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx
@@ -16,7 +16,7 @@ function getNavigationTarget(api: ApiMetadata): { to: string; state?: HomeLocati
   }
 
   if (kind === 'agent') {
-    return { to: LocationsService.getAgentChatUrl(api.name) };
+    return { to: LocationsService.getAgentInfoUrl(api.name) };
   }
 
   if (kind === 'plugin') {

--- a/src/experiences/CategoryPills/CategoryPills.tsx
+++ b/src/experiences/CategoryPills/CategoryPills.tsx
@@ -21,7 +21,7 @@ interface CategoryDef {
 const categories: CategoryDef[] = [
   { label: 'All assets' },
   { label: 'APIs', kindValue: 'rest', icon: <PlugConnectedRegular /> },
-  // { label: 'Agents', kindValue: 'agent', icon: <BotRegular /> },
+  { label: 'Agents', kindValue: 'agent', icon: <BotRegular /> },
   { label: 'MCP servers', kindValue: 'mcp', icon: <LinkMultipleRegular /> },
   // { label: 'Models', kindValue: 'languagemodel', icon: <BrainCircuitRegular /> },
   { label: 'Plugins', kindValue: 'plugin', icon: <PuzzlePieceRegular /> },

--- a/src/experiences/VersionSelect/VersionSelect.module.scss
+++ b/src/experiences/VersionSelect/VersionSelect.module.scss
@@ -1,0 +1,21 @@
+.versionSelect {
+  label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 600;
+  }
+
+  .dropdown {
+    background: var(--colorNeutralBackground1);
+  }
+
+  &.isInline {
+    label {
+      margin-bottom: 8px;
+    }
+
+    .dropdown {
+      min-width: 175px;
+    }
+  }
+}

--- a/src/experiences/VersionSelect/VersionSelect.tsx
+++ b/src/experiences/VersionSelect/VersionSelect.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback } from 'react';
+import { Dropdown, Option } from '@fluentui/react-components';
+import classNames from 'classnames';
+import styles from './VersionSelect.module.scss';
+
+/**
+ * Minimal shape any version-like entity must satisfy. Both `ApiVersion` and
+ * `AgentVersion` are compatible with this.
+ */
+export interface VersionOption {
+  name: string;
+  title?: string;
+}
+
+interface Props {
+  /** id used to associate the label with the dropdown */
+  id?: string;
+  versions: VersionOption[];
+  selectedName?: string;
+  /** Inline (compact) layout uses small dropdown size and tighter spacing. */
+  isInline?: boolean;
+  disabled?: boolean;
+  label?: string;
+  placeholder?: string;
+  /** Text shown when no version is selected and `selectedName` resolves to nothing. */
+  noVersionLabel?: string;
+  onChange: (name: string) => void;
+}
+
+const DEFAULT_NO_VERSION_LABEL = "Version isn't available";
+
+export const VersionSelect: React.FC<Props> = ({
+  id = 'version-select',
+  versions,
+  selectedName,
+  isInline,
+  disabled,
+  label = 'Version',
+  placeholder = 'Select version',
+  noVersionLabel = DEFAULT_NO_VERSION_LABEL,
+  onChange,
+}) => {
+  const handleSelect = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>(
+    (_, data) => {
+      const next = data.optionValue ?? data.selectedOptions[0];
+      if (next) onChange(next);
+    },
+    [onChange]
+  );
+
+  const selected = versions.find((v) => v.name === selectedName);
+  const valueLabel = selected?.title ?? selected?.name ?? noVersionLabel;
+  const isDisabled = disabled ?? versions.length === 0;
+
+  return (
+    <div className={classNames(styles.versionSelect, isInline && styles.isInline)}>
+      <label htmlFor={id}>{label}</label>
+      <Dropdown
+        id={id}
+        className={styles.dropdown}
+        placeholder={placeholder}
+        size={isInline ? 'small' : 'medium'}
+        value={valueLabel}
+        selectedOptions={selectedName ? [selectedName] : []}
+        disabled={isDisabled}
+        onOptionSelect={handleSelect}
+      >
+        {versions.map((v) => (
+          <Option key={v.name} value={v.name}>
+            {v.title || v.name}
+          </Option>
+        ))}
+      </Dropdown>
+    </div>
+  );
+};
+
+export default React.memo(VersionSelect);

--- a/src/experiences/VersionSelect/index.ts
+++ b/src/experiences/VersionSelect/index.ts
@@ -1,0 +1,3 @@
+export { VersionSelect } from './VersionSelect';
+export type { VersionOption } from './VersionSelect';
+export { default } from './VersionSelect';

--- a/src/hooks/useAgentDefinition.ts
+++ b/src/hooks/useAgentDefinition.ts
@@ -1,0 +1,17 @@
+import { useRecoilValue } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
+import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
+import { useApiService } from '@/hooks/useApiService';
+import { QueryKeys } from '@/constants/QueryKeys';
+
+export function useAgentDefinition(agentName?: string, versionName?: string) {
+  const ApiService = useApiService();
+  const isAuthenticated = useRecoilValue(isAuthenticatedAtom);
+
+  return useQuery<string | undefined>({
+    queryKey: [QueryKeys.AgentDefinition, agentName, versionName],
+    queryFn: () => ApiService.getAgentDefinition(agentName!, versionName!),
+    staleTime: Infinity,
+    enabled: Boolean(isAuthenticated && agentName && versionName),
+  });
+}

--- a/src/hooks/useAgentVersions.ts
+++ b/src/hooks/useAgentVersions.ts
@@ -1,0 +1,18 @@
+import { useRecoilValue } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
+import { AgentVersion } from '@/types/agent';
+import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
+import { useApiService } from '@/hooks/useApiService';
+import { QueryKeys } from '@/constants/QueryKeys';
+
+export function useAgentVersions(agentName?: string) {
+  const ApiService = useApiService();
+  const isAuthenticated = useRecoilValue(isAuthenticatedAtom);
+
+  return useQuery<AgentVersion[]>({
+    queryKey: [QueryKeys.AgentVersions, agentName],
+    queryFn: () => ApiService.getAgentVersions(agentName!),
+    staleTime: Infinity,
+    enabled: Boolean(isAuthenticated && agentName),
+  });
+}

--- a/src/pages/AgentInfo/AgentInfo.module.scss
+++ b/src/pages/AgentInfo/AgentInfo.module.scss
@@ -1,0 +1,4 @@
+/* Page-specific styles for AgentInfo. Currently relies on DetailPageLayout. */
+.placeholder {
+  display: none;
+}

--- a/src/pages/AgentInfo/AgentInfo.module.scss
+++ b/src/pages/AgentInfo/AgentInfo.module.scss
@@ -10,19 +10,6 @@
   gap: 24px;
 }
 
-.selectionDropdown {
-  label {
-    display: block;
-    margin-bottom: 8px;
-    font-weight: 600;
-  }
-
-  .dropdown {
-    min-width: 175px;
-    background: var(--colorNeutralBackground1);
-  }
-}
-
 .downloadLink {
   display: inline-flex;
   align-items: center;

--- a/src/pages/AgentInfo/AgentInfo.module.scss
+++ b/src/pages/AgentInfo/AgentInfo.module.scss
@@ -3,20 +3,6 @@
   display: none;
 }
 
-.headerSelector {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 24px;
-}
-
-.downloadLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding-bottom: 6px;
-}
-
 .markdown {
   line-height: 1.5;
 

--- a/src/pages/AgentInfo/AgentInfo.module.scss
+++ b/src/pages/AgentInfo/AgentInfo.module.scss
@@ -3,17 +3,80 @@
   display: none;
 }
 
-.versionSelector {
+.headerSelector {
   display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 24px;
+}
+
+.selectionDropdown {
+  label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+
+  .dropdown {
+    min-width: 175px;
+    background: var(--colorNeutralBackground1);
+  }
+}
+
+.downloadLink {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
+  padding-bottom: 6px;
 }
 
-.versionLabel {
-  color: var(--colorNeutralForeground3);
-  font-weight: 600;
-}
+.markdown {
+  line-height: 1.5;
 
-.versionDropdown {
-  min-width: 200px;
+  :global {
+    p,
+    ul,
+    ol {
+      margin-top: 0;
+      margin-bottom: 0.5em;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 1em;
+      margin-bottom: 0.4em;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.5em;
+    }
+
+    li {
+      margin-bottom: 0.15em;
+    }
+
+    code {
+      padding: 2px 6px;
+      border-radius: 4px;
+      background-color: var(--colorNeutralBackground3);
+      font-size: 0.85em;
+    }
+
+    pre {
+      padding: 12px;
+      overflow-x: auto;
+      border-radius: 6px;
+      background-color: var(--colorNeutralBackground3);
+
+      code {
+        padding: 0;
+        background: none;
+      }
+    }
+  }
 }

--- a/src/pages/AgentInfo/AgentInfo.module.scss
+++ b/src/pages/AgentInfo/AgentInfo.module.scss
@@ -1,4 +1,19 @@
-/* Page-specific styles for AgentInfo. Currently relies on DetailPageLayout. */
+/* Page-specific styles for AgentInfo. */
 .placeholder {
   display: none;
+}
+
+.versionSelector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.versionLabel {
+  color: var(--colorNeutralForeground3);
+  font-weight: 600;
+}
+
+.versionDropdown {
+  min-width: 200px;
 }

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Dropdown, Link, Option, Tab, TabList } from '@fluentui/react-components';
+import { Badge, Link, Tab, TabList } from '@fluentui/react-components';
 import { ArrowDownloadRegular, CodeRegular, DocumentRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useAgentVersions } from '@/hooks/useAgentVersions';
@@ -10,12 +10,11 @@ import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
+import { VersionSelect } from '@/experiences/VersionSelect';
 import { AgentDefinition } from '@/experiences/AgentDefinition';
 import styles from './AgentInfo.module.scss';
 
 type AgentTab = 'documentation' | 'definition' | 'properties';
-
-const NO_VERSION_LABEL = "Version isn't available";
 
 export const AgentInfo: React.FC = () => {
   const { name } = useParams<{ name: string }>();
@@ -35,18 +34,10 @@ export const AgentInfo: React.FC = () => {
 
   const definition = useAgentDefinition(api.data?.name, selectedVersion);
 
-  const handleVersionChange = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>((_, data) => {
-    const next = data.optionValue ?? data.selectedOptions[0];
-    if (next) setSelectedVersion(next);
-  }, []);
-
   const handleDownload = useCallback(
     (e: React.MouseEvent) => {
-      if (!api.data?.name || !selectedVersion || !definition.data) {
-        e.preventDefault();
-        return;
-      }
       e.preventDefault();
+      if (!api.data?.name || !selectedVersion || !definition.data) return;
       const blob = new Blob([definition.data], { type: 'text/markdown' });
       const url = URL.createObjectURL(blob);
       try {
@@ -65,36 +56,20 @@ export const AgentInfo: React.FC = () => {
   );
 
   const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
-  const selectedVersionTitle = useMemo(
-    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? NO_VERSION_LABEL,
-    [versionOptions, selectedVersion]
-  );
-
   const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
   const hasDefinition = !!definition.data;
 
   const headerSelector =
     versionOptions.length > 0 ? (
       <div className={styles.headerSelector}>
-        <div className={styles.selectionDropdown}>
-          <label htmlFor="agent-version-select">Version</label>
-          <Dropdown
-            id="agent-version-select"
-            className={styles.dropdown}
-            placeholder="Select agent version"
-            size="small"
-            value={selectedVersionTitle}
-            selectedOptions={selectedVersion ? [selectedVersion] : []}
-            disabled={!versionOptions.length}
-            onOptionSelect={handleVersionChange}
-          >
-            {versionOptions.map((v) => (
-              <Option key={v.name} value={v.name}>
-                {v.title || v.name}
-              </Option>
-            ))}
-          </Dropdown>
-        </div>
+        <VersionSelect
+          id="agent-version-select"
+          versions={versionOptions}
+          selectedName={selectedVersion}
+          placeholder="Select agent version"
+          isInline
+          onChange={setSelectedVersion}
+        />
         {hasDefinition && (
           <Link className={styles.downloadLink} href="#" onClick={handleDownload}>
             <ArrowDownloadRegular /> Download definition

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -15,7 +15,7 @@ type AgentTab = 'documentation' | 'definition' | 'properties';
 export const AgentInfo: React.FC = () => {
   const { name } = useParams<{ name: string }>();
   const api = useApi(name);
-  const [selectedTab, setSelectedTab] = useState<AgentTab>('documentation');
+  const [selectedTab, setSelectedTab] = useState<AgentTab>('definition');
 
   setDocumentTitle(`Agent${api.data?.title ? ` - ${api.data.title}` : ''}`);
 
@@ -40,11 +40,11 @@ export const AgentInfo: React.FC = () => {
       }
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as AgentTab)}>
-          <Tab icon={<DocumentRegular />} value="documentation">
-            Documentation
-          </Tab>
           <Tab icon={<CodeRegular />} value="definition">
             Definition
+          </Tab>
+          <Tab icon={<DocumentRegular />} value="documentation">
+            Documentation
           </Tab>
           {hasCustomProps && <Tab value="properties">Additional properties</Tab>}
         </TabList>

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -1,25 +1,67 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Tab, TabList } from '@fluentui/react-components';
+import { Badge, Dropdown, Option, Tab, TabList } from '@fluentui/react-components';
 import { CodeRegular, DocumentRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
+import { useAgentVersions } from '@/hooks/useAgentVersions';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
 import { AgentDefinition } from '@/experiences/AgentDefinition';
+import styles from './AgentInfo.module.scss';
 
 type AgentTab = 'documentation' | 'definition' | 'properties';
 
 export const AgentInfo: React.FC = () => {
   const { name } = useParams<{ name: string }>();
   const api = useApi(name);
+  const versions = useAgentVersions(api.data?.name);
+  const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
   const [selectedTab, setSelectedTab] = useState<AgentTab>('definition');
 
   setDocumentTitle(`Agent${api.data?.title ? ` - ${api.data.title}` : ''}`);
 
+  // Auto-select the first version once versions load.
+  useEffect(() => {
+    if (!selectedVersion && versions.data && versions.data.length > 0) {
+      setSelectedVersion(versions.data[0].name);
+    }
+  }, [versions.data, selectedVersion]);
+
+  const handleVersionChange = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>((_, data) => {
+    const next = data.optionValue ?? data.selectedOptions[0];
+    if (next) setSelectedVersion(next);
+  }, []);
+
+  const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
+  const selectedVersionTitle = useMemo(
+    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? '',
+    [versionOptions, selectedVersion]
+  );
+
   const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
+
+  const versionSelector =
+    versionOptions.length > 0 ? (
+      <div className={styles.versionSelector}>
+        <span className={styles.versionLabel}>Version</span>
+        <Dropdown
+          className={styles.versionDropdown}
+          aria-label="Agent version"
+          value={selectedVersionTitle}
+          selectedOptions={selectedVersion ? [selectedVersion] : []}
+          onOptionSelect={handleVersionChange}
+        >
+          {versionOptions.map((v) => (
+            <Option key={v.name} value={v.name} text={v.title ?? v.name}>
+              {v.title ?? v.name}
+            </Option>
+          ))}
+        </Dropdown>
+      </div>
+    ) : undefined;
 
   return (
     <DetailPageLayout
@@ -38,6 +80,7 @@ export const AgentInfo: React.FC = () => {
           {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </>
       }
+      selector={versionSelector}
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as AgentTab)}>
           <Tab icon={<CodeRegular />} value="definition">
@@ -63,7 +106,9 @@ export const AgentInfo: React.FC = () => {
           <EmptyStateMessage>No description available for this agent.</EmptyStateMessage>
         ))}
 
-      {api.data && selectedTab === 'definition' && <AgentDefinition agentName={api.data.name} />}
+      {api.data && selectedTab === 'definition' && (
+        <AgentDefinition agentName={api.data.name} versionName={selectedVersion} />
+      )}
 
       {api.data && selectedTab === 'properties' && hasCustomProps && (
         <CustomMetadata value={api.data.customProperties} />

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Link, Tab, TabList } from '@fluentui/react-components';
+import { Badge, Button, Tab, TabList } from '@fluentui/react-components';
 import { ArrowDownloadRegular, CodeRegular, DocumentRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useAgentVersions } from '@/hooks/useAgentVersions';
@@ -10,6 +10,7 @@ import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
+import { HeaderActions } from '@/experiences/HeaderActions';
 import { VersionSelect } from '@/experiences/VersionSelect';
 import { AgentDefinition } from '@/experiences/AgentDefinition';
 import styles from './AgentInfo.module.scss';
@@ -34,26 +35,22 @@ export const AgentInfo: React.FC = () => {
 
   const definition = useAgentDefinition(api.data?.name, selectedVersion);
 
-  const handleDownload = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      if (!api.data?.name || !selectedVersion || !definition.data) return;
-      const blob = new Blob([definition.data], { type: 'text/markdown' });
-      const url = URL.createObjectURL(blob);
-      try {
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = `${api.data.name}-${selectedVersion}-definition.md`;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-      } finally {
-        // Defer revoke so the click is processed first.
-        setTimeout(() => URL.revokeObjectURL(url), 0);
-      }
-    },
-    [api.data?.name, selectedVersion, definition.data]
-  );
+  const handleDownload = useCallback(() => {
+    if (!api.data?.name || !selectedVersion || !definition.data) return;
+    const blob = new Blob([definition.data], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    try {
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${api.data.name}-${selectedVersion}-definition.md`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } finally {
+      // Defer revoke so the click is processed first.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+  }, [api.data?.name, selectedVersion, definition.data]);
 
   const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
   const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
@@ -61,21 +58,14 @@ export const AgentInfo: React.FC = () => {
 
   const headerSelector =
     versionOptions.length > 0 ? (
-      <div className={styles.headerSelector}>
-        <VersionSelect
-          id="agent-version-select"
-          versions={versionOptions}
-          selectedName={selectedVersion}
-          placeholder="Select agent version"
-          isInline
-          onChange={setSelectedVersion}
-        />
-        {hasDefinition && (
-          <Link className={styles.downloadLink} href="#" onClick={handleDownload}>
-            <ArrowDownloadRegular /> Download definition
-          </Link>
-        )}
-      </div>
+      <VersionSelect
+        id="agent-version-select"
+        versions={versionOptions}
+        selectedName={selectedVersion}
+        placeholder="Select agent version"
+        isInline
+        onChange={setSelectedVersion}
+      />
     ) : undefined;
 
   return (
@@ -96,6 +86,15 @@ export const AgentInfo: React.FC = () => {
         </>
       }
       selector={headerSelector}
+      headerActions={
+        hasDefinition ? (
+          <HeaderActions>
+            <Button appearance="primary" icon={<ArrowDownloadRegular />} onClick={handleDownload}>
+              Download definition
+            </Button>
+          </HeaderActions>
+        ) : undefined
+      }
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as AgentTab)}>
           <Tab icon={<CodeRegular />} value="definition">

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Badge, Tab, TabList } from '@fluentui/react-components';
+import { CodeRegular, DocumentRegular } from '@fluentui/react-icons';
+import { useApi } from '@/hooks/useApi';
+import { setDocumentTitle } from '@/utils/dom';
+import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import CustomMetadata from '@/components/CustomMetadata';
+import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
+import { AgentDefinition } from '@/experiences/AgentDefinition';
+
+type AgentTab = 'documentation' | 'definition' | 'properties';
+
+export const AgentInfo: React.FC = () => {
+  const { name } = useParams<{ name: string }>();
+  const api = useApi(name);
+  const [selectedTab, setSelectedTab] = useState<AgentTab>('documentation');
+
+  setDocumentTitle(`Agent${api.data?.title ? ` - ${api.data.title}` : ''}`);
+
+  const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
+
+  return (
+    <DetailPageLayout
+      title={api.data?.title}
+      summary={api.data?.summary}
+      metadata={
+        <>
+          <Badge appearance="filled" color="brand" shape="circular">
+            Agent
+          </Badge>
+          {api.data?.lifecycleStage && (
+            <Badge appearance="tint" color="brand" shape="circular">
+              {api.data.lifecycleStage}
+            </Badge>
+          )}
+          {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
+        </>
+      }
+      tabs={
+        <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as AgentTab)}>
+          <Tab icon={<DocumentRegular />} value="documentation">
+            Documentation
+          </Tab>
+          <Tab icon={<CodeRegular />} value="definition">
+            Definition
+          </Tab>
+          {hasCustomProps && <Tab value="properties">Additional properties</Tab>}
+        </TabList>
+      }
+      isLoading={api.isLoading}
+      error={api.isError ? 'Failed to load agent details. Please check your connection and try again.' : undefined}
+      emptyMessage={!api.isLoading && !api.isError && !api.data ? 'The specified agent does not exist.' : undefined}
+      sidebar={undefined}
+      onRetry={() => api.refetch()}
+    >
+      {api.data &&
+        selectedTab === 'documentation' &&
+        (api.data.description || api.data.summary ? (
+          <MarkdownRenderer markdown={(api.data.description || api.data.summary)!} />
+        ) : (
+          <EmptyStateMessage>No description available for this agent.</EmptyStateMessage>
+        ))}
+
+      {api.data && selectedTab === 'definition' && <AgentDefinition agentName={api.data.name} />}
+
+      {api.data && selectedTab === 'properties' && hasCustomProps && (
+        <CustomMetadata value={api.data.customProperties} />
+      )}
+    </DetailPageLayout>
+  );
+};
+
+export default React.memo(AgentInfo);

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Dropdown, Option, Tab, TabList } from '@fluentui/react-components';
-import { CodeRegular, DocumentRegular } from '@fluentui/react-icons';
+import { Badge, Dropdown, Link, Option, Tab, TabList } from '@fluentui/react-components';
+import { ArrowDownloadRegular, CodeRegular, DocumentRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useAgentVersions } from '@/hooks/useAgentVersions';
+import { useAgentDefinition } from '@/hooks/useAgentDefinition';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
@@ -13,6 +14,8 @@ import { AgentDefinition } from '@/experiences/AgentDefinition';
 import styles from './AgentInfo.module.scss';
 
 type AgentTab = 'documentation' | 'definition' | 'properties';
+
+const NO_VERSION_LABEL = "Version isn't available";
 
 export const AgentInfo: React.FC = () => {
   const { name } = useParams<{ name: string }>();
@@ -30,36 +33,73 @@ export const AgentInfo: React.FC = () => {
     }
   }, [versions.data, selectedVersion]);
 
+  const definition = useAgentDefinition(api.data?.name, selectedVersion);
+
   const handleVersionChange = useCallback<React.ComponentProps<typeof Dropdown>['onOptionSelect']>((_, data) => {
     const next = data.optionValue ?? data.selectedOptions[0];
     if (next) setSelectedVersion(next);
   }, []);
 
+  const handleDownload = useCallback(
+    (e: React.MouseEvent) => {
+      if (!api.data?.name || !selectedVersion || !definition.data) {
+        e.preventDefault();
+        return;
+      }
+      e.preventDefault();
+      const blob = new Blob([definition.data], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+      try {
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${api.data.name}-${selectedVersion}-definition.md`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      } finally {
+        // Defer revoke so the click is processed first.
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+      }
+    },
+    [api.data?.name, selectedVersion, definition.data]
+  );
+
   const versionOptions = useMemo(() => versions.data ?? [], [versions.data]);
   const selectedVersionTitle = useMemo(
-    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? '',
+    () => versionOptions.find((v) => v.name === selectedVersion)?.title ?? selectedVersion ?? NO_VERSION_LABEL,
     [versionOptions, selectedVersion]
   );
 
   const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
+  const hasDefinition = !!definition.data;
 
-  const versionSelector =
+  const headerSelector =
     versionOptions.length > 0 ? (
-      <div className={styles.versionSelector}>
-        <span className={styles.versionLabel}>Version</span>
-        <Dropdown
-          className={styles.versionDropdown}
-          aria-label="Agent version"
-          value={selectedVersionTitle}
-          selectedOptions={selectedVersion ? [selectedVersion] : []}
-          onOptionSelect={handleVersionChange}
-        >
-          {versionOptions.map((v) => (
-            <Option key={v.name} value={v.name} text={v.title ?? v.name}>
-              {v.title ?? v.name}
-            </Option>
-          ))}
-        </Dropdown>
+      <div className={styles.headerSelector}>
+        <div className={styles.selectionDropdown}>
+          <label htmlFor="agent-version-select">Version</label>
+          <Dropdown
+            id="agent-version-select"
+            className={styles.dropdown}
+            placeholder="Select agent version"
+            size="small"
+            value={selectedVersionTitle}
+            selectedOptions={selectedVersion ? [selectedVersion] : []}
+            disabled={!versionOptions.length}
+            onOptionSelect={handleVersionChange}
+          >
+            {versionOptions.map((v) => (
+              <Option key={v.name} value={v.name}>
+                {v.title || v.name}
+              </Option>
+            ))}
+          </Dropdown>
+        </div>
+        {hasDefinition && (
+          <Link className={styles.downloadLink} href="#" onClick={handleDownload}>
+            <ArrowDownloadRegular /> Download definition
+          </Link>
+        )}
       </div>
     ) : undefined;
 
@@ -80,7 +120,7 @@ export const AgentInfo: React.FC = () => {
           {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </>
       }
-      selector={versionSelector}
+      selector={headerSelector}
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as AgentTab)}>
           <Tab icon={<CodeRegular />} value="definition">
@@ -101,13 +141,15 @@ export const AgentInfo: React.FC = () => {
       {api.data &&
         selectedTab === 'documentation' &&
         (api.data.description || api.data.summary ? (
-          <MarkdownRenderer markdown={(api.data.description || api.data.summary)!} />
+          <div className={styles.markdown}>
+            <MarkdownRenderer markdown={(api.data.description || api.data.summary)!} />
+          </div>
         ) : (
           <EmptyStateMessage>No description available for this agent.</EmptyStateMessage>
         ))}
 
       {api.data && selectedTab === 'definition' && (
-        <AgentDefinition agentName={api.data.name} versionName={selectedVersion} />
+        <AgentDefinition definition={definition} hasVersion={!!selectedVersion} />
       )}
 
       {api.data && selectedTab === 'properties' && hasCustomProps && (

--- a/src/pages/AgentInfo/index.ts
+++ b/src/pages/AgentInfo/index.ts
@@ -1,0 +1,2 @@
+export { AgentInfo } from './AgentInfo';
+export { default } from './AgentInfo';

--- a/src/pages/PluginInfo/PluginInfo.tsx
+++ b/src/pages/PluginInfo/PluginInfo.tsx
@@ -38,7 +38,7 @@ function getCategoryLabel(kind: string): string {
 
 function getResourceNavigation(name: string, kind?: string): { to: string; state?: HomeLocationState } {
   const k = kind?.toLowerCase();
-  if (k === 'agent') return { to: LocationsService.getAgentChatUrl(name) };
+  if (k === 'agent') return { to: LocationsService.getAgentInfoUrl(name) };
   if (k === 'skill') return { to: LocationsService.getSkillInfoUrl(name) };
   if (k === 'languagemodel') {
     return { to: LocationsService.getModelDetailUrl(name) };

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -13,10 +13,15 @@ import { Server, ServerResponse } from '@/types/server';
 import { MetadataSchema } from '@/types/metadataSchema';
 import { PluginDetails } from '@/types/plugin';
 import { SkillEvaluationResult } from '@/types/skillEvaluation';
+import { AgentVersion } from '@/types/agent';
 import { DEFAULT_PAGE_SIZE } from '@/constants';
 
 export const ApiService: IApiService = {
-  async getApis(search: string, filters: ActiveFilterData[] = [], isSemanticSearch?: boolean): Promise<PaginatedResult<ApiMetadata>> {
+  async getApis(
+    search: string,
+    filters: ActiveFilterData[] = [],
+    isSemanticSearch?: boolean
+  ): Promise<PaginatedResult<ApiMetadata>> {
     const searchParams = new URLSearchParams();
     searchParams.set('$top', String(DEFAULT_PAGE_SIZE));
     if (search.length && !isSemanticSearch) {
@@ -41,14 +46,19 @@ export const ApiService: IApiService = {
     }
 
     if (search.length && isSemanticSearch) {
-      const response = await HttpService.post<{ value: ApiMetadata[]; nextLink?: string }>(`:search?${searchParams.toString()}`, {
-        query: search,
-        searchType: 'vector',
-      });
+      const response = await HttpService.post<{ value: ApiMetadata[]; nextLink?: string }>(
+        `:search?${searchParams.toString()}`,
+        {
+          query: search,
+          searchType: 'vector',
+        }
+      );
       return { value: response.value || [], nextLink: response.nextLink };
     }
 
-    const response = await HttpService.get<{ value: ApiMetadata[]; nextLink?: string }>(`/apis?${searchParams.toString()}`);
+    const response = await HttpService.get<{ value: ApiMetadata[]; nextLink?: string }>(
+      `/apis?${searchParams.toString()}`
+    );
     return { value: response.value || [], nextLink: response.nextLink };
   },
 
@@ -67,16 +77,24 @@ export const ApiService: IApiService = {
   },
 
   async getVersions(apiName: string, _resourceType: ResourceType = 'apis'): Promise<ApiVersion[]> {
-    const response = await HttpService.get<{ value: ApiVersion[] }>(`/apis/${apiName}/versions?$top=${DEFAULT_PAGE_SIZE}`);
+    const response = await HttpService.get<{ value: ApiVersion[] }>(
+      `/apis/${apiName}/versions?$top=${DEFAULT_PAGE_SIZE}`
+    );
     return response.value || [];
   },
 
   async getDeployments(apiName: string, _resourceType: ResourceType = 'apis'): Promise<ApiDeployment[]> {
-    const response = await HttpService.get<{ value: ApiDeployment[] }>(`/apis/${apiName}/deployments?$top=${DEFAULT_PAGE_SIZE}`);
+    const response = await HttpService.get<{ value: ApiDeployment[] }>(
+      `/apis/${apiName}/deployments?$top=${DEFAULT_PAGE_SIZE}`
+    );
     return response.value || [];
   },
 
-  async getDefinitions(apiName: string, version: string, _resourceType: ResourceType = 'apis'): Promise<ApiDefinition[]> {
+  async getDefinitions(
+    apiName: string,
+    version: string,
+    _resourceType: ResourceType = 'apis'
+  ): Promise<ApiDefinition[]> {
     const response = await HttpService.get<{ value: ApiDefinition[] }>(
       `/apis/${apiName}/versions/${version}/definitions?$top=${DEFAULT_PAGE_SIZE}`
     );
@@ -130,13 +148,30 @@ export const ApiService: IApiService = {
   },
 
   async getMetadataSchemas(): Promise<MetadataSchema[]> {
-    const response = await HttpService.get<MetadataSchema[]>(`/metadataSchemas?$top=${DEFAULT_PAGE_SIZE}`, { skipWorkspacePrefix: true });
+    const response = await HttpService.get<MetadataSchema[]>(`/metadataSchemas?$top=${DEFAULT_PAGE_SIZE}`, {
+      skipWorkspacePrefix: true,
+    });
     return response || [];
   },
 
   async getSkillEvaluationResult(skillName: string): Promise<SkillEvaluationResult | undefined> {
-    return await HttpService.getOptional<SkillEvaluationResult>(
-      `/skills/${skillName}/evaluationResults/default`
+    return await HttpService.getOptional<SkillEvaluationResult>(`/skills/${skillName}/evaluationResults/default`);
+  },
+
+  async getAgentVersions(agentName: string): Promise<AgentVersion[]> {
+    const response = await HttpService.get<{ value: AgentVersion[] }>(
+      `/agents/${encodeURIComponent(agentName)}/versions?$top=${DEFAULT_PAGE_SIZE}`
     );
+    return response?.value || [];
+  },
+
+  async getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined> {
+    return await HttpService.getText(
+      `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
+    );
+  },
+
+  getAgentDefinitionDownloadPath(agentName: string, versionName: string): string {
+    return `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`;
   },
 };

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -170,8 +170,4 @@ export const ApiService: IApiService = {
       `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
     );
   },
-
-  getAgentDefinitionDownloadPath(agentName: string, versionName: string): string {
-    return `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`;
-  },
 };

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -135,6 +135,43 @@ export const HttpService = {
     }
   },
 
+  /** GET that returns the raw response body as text. Uses the same auth/workspace logic as `get`. */
+  async getText(endpoint: string, options?: RequestOptions): Promise<string | undefined> {
+    const { AuthService } = getRecoil(appServicesAtom);
+    const config = getRecoil(configAtom);
+    const accessToken = await AuthService.getAccessToken();
+
+    const init: RequestInit = {
+      method: 'GET',
+      headers: new Headers({ Accept: 'text/plain, text/markdown, */*' }),
+    };
+
+    if (accessToken) {
+      (init.headers as Headers).append('Authorization', 'Bearer ' + accessToken);
+    }
+
+    let baseUrl = `https://${config.dataApiHostName}`;
+    if (!options?.skipWorkspacePrefix && !config.dataApiHostName.includes('/workspaces/default')) {
+      baseUrl += '/workspaces/default';
+    }
+
+    const response = await fetch(`${baseUrl}${endpoint}`, init);
+
+    if (response.status === 404) return undefined;
+    if (response.status === 401 || response.status === 403) {
+      if (accessToken) {
+        setRecoil(isAccessDeniedAtom, true);
+        return undefined;
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} fetching ${endpoint}`);
+    }
+
+    return await response.text();
+  },
+
   post<T>(endpoint: string, payload?: any): Promise<T | undefined> {
     return makeRequest<T>(endpoint, 'POST', payload);
   },

--- a/src/services/LocationsService.ts
+++ b/src/services/LocationsService.ts
@@ -47,11 +47,20 @@ export const LocationsService = {
     return `/agents/${name}`;
   },
 
+  getAgentInfoUrl(name: string): string {
+    return `/agents/${name}`;
+  },
+
   getModelPlaygroundUrl(name: string): string {
     return `/languageModels/${name}/playground`;
   },
 
-  getApiSchemaExplorerUrl(api: string, version: string, definition: string, resourceType: ResourceType = 'apis'): string {
+  getApiSchemaExplorerUrl(
+    api: string,
+    version: string,
+    definition: string,
+    resourceType: ResourceType = 'apis'
+  ): string {
     return `/${resourceType}/${api}/versions/${version}/definitions/${definition}`;
   },
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,0 +1,17 @@
+/**
+ * Type definitions for agent assets in Azure API Center.
+ *
+ * APIs of kind "agent" expose versioned definitions through dedicated
+ * endpoints under /agents/{name}. The definition artifact is markdown.
+ */
+
+export interface AgentVersion {
+  name: string;
+  title?: string;
+  lifecycleStage?: string;
+}
+
+export interface AgentArtifact {
+  name: string;
+  contentType?: string;
+}

--- a/src/types/services/IApiService.ts
+++ b/src/types/services/IApiService.ts
@@ -9,6 +9,7 @@ import { Server } from '@/types/server';
 import { MetadataSchema } from '@/types/metadataSchema';
 import { PluginDetails } from '@/types/plugin';
 import { SkillEvaluationResult } from '@/types/skillEvaluation';
+import { AgentVersion } from '@/types/agent';
 
 export interface PaginatedResult<T> {
   value: T[];
@@ -16,7 +17,11 @@ export interface PaginatedResult<T> {
 }
 
 export interface IApiService {
-  getApis(search: string, filters?: ActiveFilterData[], isSemanticSearch?: boolean): Promise<PaginatedResult<ApiMetadata>>;
+  getApis(
+    search: string,
+    filters?: ActiveFilterData[],
+    isSemanticSearch?: boolean
+  ): Promise<PaginatedResult<ApiMetadata>>;
   getApisByNextLink(nextLink: string): Promise<PaginatedResult<ApiMetadata>>;
   getApi(id: string, resourceType?: ResourceType): Promise<ApiMetadata>;
   getServer(name: string): Promise<Server | undefined>;
@@ -32,4 +37,7 @@ export interface IApiService {
   getMetadataSchemas(): Promise<MetadataSchema[]>;
   getPlugin(name: string): Promise<PluginDetails>;
   getSkillEvaluationResult(skillName: string): Promise<SkillEvaluationResult | undefined>;
+  getAgentVersions(agentName: string): Promise<AgentVersion[]>;
+  getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined>;
+  getAgentDefinitionDownloadPath(agentName: string, versionName: string): string;
 }

--- a/src/types/services/IApiService.ts
+++ b/src/types/services/IApiService.ts
@@ -39,5 +39,4 @@ export interface IApiService {
   getSkillEvaluationResult(skillName: string): Promise<SkillEvaluationResult | undefined>;
   getAgentVersions(agentName: string): Promise<AgentVersion[]>;
   getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined>;
-  getAgentDefinitionDownloadPath(agentName: string, versionName: string): string;
 }


### PR DESCRIPTION
Adds UI for APIs of `kind: "agent"`, mirroring the Skill detail page pattern with an additional **Definition** tab that fetches and renders the markdown agent definition.

## What ships

### List page
- **Agents** category pill enabled in `CategoryPills` (between APIs and MCP servers).
- Agent badge on cards already wired via `STANDALONE_KINDS`.

### Detail page (new): `/agents/:name` → `AgentInfo`
Replaces the old `AgentChat` route. Uses `DetailPageLayout`.
- **Header**: title, summary, Agent badge, lifecycle badge, last updated.
- **Selector** (above tabs): version dropdown via the new shared `VersionSelect` component (`isInline` style), only shown when versions exist.
- **Header actions** (top right): primary **Download definition** button — only rendered when a definition has loaded. Generates a blob from the in-memory markdown so no extra round-trip / CORS risk.
- **Tabs**:
  1. **Definition** (default) — YAML frontmatter rendered as a striped key/value table (GitHub-style); markdown body rendered with tighter spacing.
  2. **Documentation** — markdown of `description` / `summary`.
  3. **Additional properties** — only when `customProperties` is non-empty.

### Data layer
- `ApiService.getAgentVersions(name)` → `GET /agents/{name}/versions`
- `ApiService.getAgentDefinition(name, version)` → fetches the `definition` artifact `/download` and returns text.
- New `HttpService.getText` helper for raw text endpoints (auth + workspace prefix).
- New hooks `useAgentVersions`, `useAgentDefinition`.
- New types `AgentVersion`, `AgentArtifact`.

### Refactor: shared `VersionSelect`
Extracted from the version slot of `ApiDefinitionSelect`. Both `ApiDefinitionSelect` (for the API detail page) and `AgentInfo` now use the same component, ensuring identical styling and behavior. Generic over `{ name, title? }[]`.

### Routing & links
- `/agents/:name` → `AgentInfo` (was `AgentChat`). The `AgentChat` page file remains in the tree but is unrouted; deletion is left as a follow-up.
- Agent links in `ApiList`, `ApiSearchAutoComplete`, and `PluginInfo` now go through `LocationsService.getAgentInfoUrl`.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-07-agent-ui-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-agent-ui.md`

## Verification

- `npm run build` and targeted `eslint`/`stylelint` pass for all new/modified files.
- Pre-existing codebase issues (~395 prettier CRLF errors, `ApiAuthForm.tsx` / `ConnectPanel.tsx` TS errors, Fluent UI `--colorXxx` token kebab-case stylelint warnings, `_resourceType` unused-param warnings) were left untouched.
- Smoke-tested locally against a live data API (versions list, definition fetch, frontmatter rendering, download).

## Out of scope

- Deleting the unused `AgentChat` page directory.
- Automated tests (no test framework configured in the project).
- Fixing pre-existing lint errors.
