### PR TITLE
fix: hide homepage endpoint bar until docs and auth model are ready

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -57,9 +57,11 @@ export const Home: React.FC = () => {
         </div>
       </div>
 
+      {/* TODO: Re-enable endpoint bar once documentation and auth model are ready
       <div className={styles.endpointBarWrapper}>
         <ConnectBar dataApiHostName={config.dataApiHostName} />
       </div>
+      */}
 
       <section className={styles.content}>
         <div className={styles.pillsRow}>


### PR DESCRIPTION
## What
Comments out the `ConnectBar` (copyable endpoint) on the homepage.

## Why
Documentation and auth model aren't ready yet — the endpoint on the homepage is confusing customers. Asset-level endpoints on individual API pages remain unchanged.

## What's next
Re-enable once docs and auth model are finalized.