### PR TITLE
feat: MCP transport badges + badge system audit

### DIFF
--- a/src/components/ParamSchemaDefinition/ParamSchemaDefinition.tsx
+++ b/src/components/ParamSchemaDefinition/ParamSchemaDefinition.tsx
@@ -136,7 +136,7 @@ export const ParamSchemaDefinition: React.FC<Props> = ({
       return (
         <>
           Type:
-          <Badge className={styles.badge} appearance="tint" color="informative" shape="rounded">
+          <Badge className={styles.badge} appearance="tint" color="informative" shape="circular">
             {schema.typeLabel}
           </Badge>
         </>

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -9,6 +9,7 @@ import { ApiCard, type ApiCardApi } from '@/components/ApiCard';
 import { InfoTable } from '@/components/InfoTable';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { formatKindDisplay } from '@/utils/formatKind';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import { apiAdapter } from '@/experiences/ApiList/apiAdapter';
 import { ENABLE_LIST_EVAL_BADGES } from '@/constants/featureFlags';
 import { ContributeCard } from '@/experiences/ContributeCard';
@@ -153,7 +154,7 @@ export const ApiList: React.FC = () => {
             )}
             <InfoTable.Cell>
               {!!api.lifecycleStage && (
-                <Badge appearance="tint" color="informative" shape="rounded">
+                <Badge appearance="tint" color={getLifecycleBadgeColor(api.lifecycleStage)} shape="circular">
                   {api.lifecycleStage}
                 </Badge>
               )}

--- a/src/experiences/SkillEvaluation/SkillEvaluationDetails.tsx
+++ b/src/experiences/SkillEvaluation/SkillEvaluationDetails.tsx
@@ -149,9 +149,15 @@ export const SkillEvaluationDetails: React.FC<SkillEvaluationDetailsProps> = ({
               <div className={styles.recContent}>
                 <h4>
                   {rec.title}
-                  <span className={`${styles.impactTag} ${rec.impact === 'high' ? styles.impactTagHigh : styles.impactTagMedium}`}>
+                  <Badge
+                    appearance="filled"
+                    color={rec.impact === 'high' ? 'danger' : 'warning'}
+                    shape="circular"
+                    size="small"
+                    style={{ marginLeft: 6, verticalAlign: 'middle' }}
+                  >
                     {rec.impact === 'high' ? 'High Impact' : 'Medium'}
-                  </span>
+                  </Badge>
                 </h4>
                 <p>{rec.description}</p>
               </div>

--- a/src/pages/AgentChat/AgentChat.tsx
+++ b/src/pages/AgentChat/AgentChat.tsx
@@ -11,6 +11,7 @@ import {
 import { Link, useParams } from 'react-router-dom';
 import { LocationsService } from '@/services/LocationsService';
 import { useApi } from '@/hooks/useApi';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import styles from './AgentChat.module.scss';
 
@@ -200,7 +201,7 @@ export const AgentChat: React.FC = () => {
         {agentSummary && <p className={styles.summary}>{agentSummary}</p>}
         <div className={styles.metadata}>
           {agentKind && <Badge appearance="filled" color="brand" shape="circular">{agentKind.toUpperCase()}</Badge>}
-          {api.data?.lifecycleStage && <Badge appearance="tint" color="brand" shape="circular">{api.data.lifecycleStage}</Badge>}
+          {api.data?.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">{api.data.lifecycleStage}</Badge>}
           {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </div>
       </section>

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -6,6 +6,7 @@ import { useApi } from '@/hooks/useApi';
 import { useAgentVersions } from '@/hooks/useAgentVersions';
 import { useAgentDefinition } from '@/hooks/useAgentDefinition';
 import { setDocumentTitle } from '@/utils/dom';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
@@ -78,7 +79,7 @@ export const AgentInfo: React.FC = () => {
             Agent
           </Badge>
           {api.data?.lifecycleStage && (
-            <Badge appearance="tint" color="brand" shape="circular">
+            <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
               {api.data.lifecycleStage}
             </Badge>
           )}

--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Button, Dropdown, Link, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Option, SplitButton, Spinner, Tab, TabList } from '@fluentui/react-components';
-import { ArrowDownloadRegular, DocumentRegular, ListRegular, WindowConsoleRegular } from '@fluentui/react-icons';
+import { ArrowDownloadRegular, DocumentRegular, ListRegular, TagRegular, WindowConsoleRegular } from '@fluentui/react-icons';
 import { useRecoilValue } from 'recoil';
 import { useApi } from '@/hooks/useApi';
 import { useServer } from '@/hooks/useServer';
@@ -13,6 +13,7 @@ import ApiDefinitionSelect, { ApiDefinitionSelection } from '@/experiences/ApiDe
 import ApiAdditionalInfo from '@/experiences/ApiAdditionalInfo';
 import { HeaderActions } from '@/experiences/HeaderActions';
 import { formatKindDisplay } from '@/utils/formatKind';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import { buildSkillDeeplink } from '@/utils/skillDeeplink';
 import { useApiSpec } from '@/hooks/useApiSpec';
 import { useApiSpecUrl } from '@/hooks/useApiSpecUrl';
@@ -263,23 +264,37 @@ export const ApiDetailPage: React.FC = () => {
               {formatKindDisplay(kind)}
             </Badge>
           )}
+          {isMcp && hasLocalInstall && hasRemoteInstall && (
+            <Badge appearance="tint" color="brand" shape="circular">Local + Remote</Badge>
+          )}
+          {isMcp && hasLocalInstall && !hasRemoteInstall && (
+            <Badge appearance="tint" color="brand" shape="circular">Local</Badge>
+          )}
+          {isMcp && !hasLocalInstall && hasRemoteInstall && (
+            <Badge appearance="tint" color="brand" shape="circular">Remote</Badge>
+          )}
           {api.data?.lifecycleStage && (
-            <Badge appearance="tint" color="brand" shape="circular">
+            <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
               {api.data.lifecycleStage}
             </Badge>
           )}
-          {customPropertyTags.map(tag => (
-            <Badge key={tag} appearance="tint" color="brand" shape="circular">
-              {tag}
-            </Badge>
-          ))}
+          {customPropertyTags.length > 0 && (
+            <>
+              <TagRegular style={{ fontSize: 16, color: 'var(--colorNeutralForeground3)', flexShrink: 0 }} />
+              {customPropertyTags.map(tag => (
+                <Badge key={tag} appearance="tint" color="informative" shape="circular">
+                  {tag}
+                </Badge>
+              ))}
+            </>
+          )}
           {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </>
       }
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
           <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
-          {isMcp && <Tab icon={<WindowConsoleRegular />} value="testconsole">Test console</Tab>}
+          {isMcp && hasRemoteInstall && <Tab icon={<WindowConsoleRegular />} value="testconsole">Test console</Tab>}
           {!isMcp && hasAdditionalInfo && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
         </TabList>
       }
@@ -365,7 +380,7 @@ export const ApiDetailPage: React.FC = () => {
           </>
         )
       )}
-      {api.data && selectedTab === 'testconsole' && isMcp && renderDocumentation()}
+      {api.data && selectedTab === 'testconsole' && isMcp && hasRemoteInstall && renderDocumentation()}
       {api.data && selectedTab === 'properties' && (
         <ApiAdditionalInfo api={api.data} />
       )}

--- a/src/pages/ApiSpec/ApiSpec.tsx
+++ b/src/pages/ApiSpec/ApiSpec.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useLocation, Link } from 'react-router-dom';
 import { Badge, Spinner, Tab, TabList } from '@fluentui/react-components';
 import { DocumentRegular } from '@fluentui/react-icons';
 import { formatKindDisplay } from '@/utils/formatKind';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import { ApiDefinitionId, ResourceType } from '@/types/apiDefinition';
 import { useApi } from '@/hooks/useApi';
 import { setDocumentTitle } from '@/utils/dom';
@@ -73,7 +74,7 @@ export const ApiSpec: React.FC = () => {
         {(api.data.kind || api.data.lifecycleStage) && (
           <div className={styles.badges}>
             {api.data.kind && <Badge appearance="filled" color="brand" shape="circular">{formatKindDisplay(api.data.kind)}</Badge>}
-            {api.data.lifecycleStage && <Badge appearance="outline">{api.data.lifecycleStage}</Badge>}
+            {api.data.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">{api.data.lifecycleStage}</Badge>}
           </div>
         )}
         {api.data.summary && <p className={styles.summary}>{api.data.summary}</p>}

--- a/src/pages/ModelDetailPage/ModelDetailPage.tsx
+++ b/src/pages/ModelDetailPage/ModelDetailPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Link, Subtitle2 } from '@fluentui/react-components';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
 
@@ -22,7 +23,7 @@ export const ModelDetailPage: React.FC = () => {
         <>
           <Badge appearance="filled" color="brand" shape="circular">Model</Badge>
           {model.data?.lifecycleStage && (
-            <Badge appearance="tint" color="brand" shape="circular">
+            <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">
               {model.data.lifecycleStage}
             </Badge>
           )}
@@ -119,7 +120,7 @@ export const ModelDetailPage: React.FC = () => {
               <Subtitle2>Task types</Subtitle2>
               <div className={styles.badges}>
                 {model.data.taskTypes.map((t) => (
-                  <Badge key={t} appearance="tint" color="informative" shape="rounded">
+                  <Badge key={t} appearance="tint" color="informative" shape="circular">
                     {t}
                   </Badge>
                 ))}
@@ -132,7 +133,7 @@ export const ModelDetailPage: React.FC = () => {
               <Subtitle2>Input types</Subtitle2>
               <div className={styles.badges}>
                 {model.data.inputTypes.map((t) => (
-                  <Badge key={t} appearance="tint" color="informative" shape="rounded">
+                  <Badge key={t} appearance="tint" color="informative" shape="circular">
                     {t}
                   </Badge>
                 ))}
@@ -145,7 +146,7 @@ export const ModelDetailPage: React.FC = () => {
               <Subtitle2>Output types</Subtitle2>
               <div className={styles.badges}>
                 {model.data.outputTypes.map((t) => (
-                  <Badge key={t} appearance="tint" color="informative" shape="rounded">
+                  <Badge key={t} appearance="tint" color="informative" shape="circular">
                     {t}
                   </Badge>
                 ))}

--- a/src/pages/ModelInfo/ModelInfo.tsx
+++ b/src/pages/ModelInfo/ModelInfo.tsx
@@ -16,6 +16,7 @@ import {
 import { Dismiss24Regular, OpenRegular } from '@fluentui/react-icons';
 import { useNavigate } from 'react-router-dom';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 
 import { LocationsService } from '@/services/LocationsService';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
@@ -87,7 +88,7 @@ export const ModelInfo: React.FC<Props> = ({ name }) => {
             <Subtitle2>Task types</Subtitle2>
             <div className={styles.badges}>
               {model.data.taskTypes.map((t) => (
-                <Badge key={t} appearance="tint" color="informative" shape="rounded">{t}</Badge>
+                <Badge key={t} appearance="tint" color="informative" shape="circular">{t}</Badge>
               ))}
             </div>
           </div>
@@ -98,7 +99,7 @@ export const ModelInfo: React.FC<Props> = ({ name }) => {
             <Subtitle2>Input types</Subtitle2>
             <div className={styles.badges}>
               {model.data.inputTypes.map((t) => (
-                <Badge key={t} appearance="tint" color="informative" shape="rounded">{t}</Badge>
+                <Badge key={t} appearance="tint" color="informative" shape="circular">{t}</Badge>
               ))}
             </div>
           </div>
@@ -109,7 +110,7 @@ export const ModelInfo: React.FC<Props> = ({ name }) => {
             <Subtitle2>Output types</Subtitle2>
             <div className={styles.badges}>
               {model.data.outputTypes.map((t) => (
-                <Badge key={t} appearance="tint" color="informative" shape="rounded">{t}</Badge>
+                <Badge key={t} appearance="tint" color="informative" shape="circular">{t}</Badge>
               ))}
             </div>
           </div>
@@ -179,7 +180,7 @@ export const ModelInfo: React.FC<Props> = ({ name }) => {
 
         {model.data.lifecycleStage && (
           <div className={styles.badges}>
-            <Badge appearance="tint" color="informative" shape="rounded">{model.data.lifecycleStage}</Badge>
+            <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">{model.data.lifecycleStage}</Badge>
           </div>
         )}
 

--- a/src/pages/ModelPlayground/ModelPlayground.tsx
+++ b/src/pages/ModelPlayground/ModelPlayground.tsx
@@ -12,6 +12,7 @@ import { Link, useParams } from 'react-router-dom';
 import { useApiDeployments } from '@/hooks/useApiDeployments';
 import { LocationsService } from '@/services/LocationsService';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import styles from './ModelPlayground.module.scss';
 
@@ -208,7 +209,7 @@ export const ModelPlayground: React.FC = () => {
         {modelSummary && <p className={styles.summary}>{modelSummary}</p>}
         <div className={styles.metadata}>
           <Badge appearance="filled" color="brand" shape="circular">Model</Badge>
-          {model.data?.lifecycleStage && <Badge appearance="tint" color="brand" shape="circular">{model.data.lifecycleStage}</Badge>}
+          {model.data?.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">{model.data.lifecycleStage}</Badge>}
           {model.data?.lastUpdated && <span>Last updated {new Date(model.data.lastUpdated).toLocaleDateString()}</span>}
         </div>
       </section>

--- a/src/pages/SkillInfo/SkillInfo.tsx
+++ b/src/pages/SkillInfo/SkillInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Button, Tab, TabList } from '@fluentui/react-components';
-import { ArrowDownloadRegular, DocumentRegular } from '@fluentui/react-icons';
+import { DocumentRegular } from '@fluentui/react-icons';
 import { useRecoilValue } from 'recoil';
 import { useApi } from '@/hooks/useApi';
 import { useSkillEvaluationResult } from '@/hooks/useSkillEvaluationResult';
@@ -9,7 +9,7 @@ import { configAtom } from '@/atoms/configAtom';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout } from '@/components/DetailPageLayout/DetailPageLayout';
 import { HeaderActions } from '@/experiences/HeaderActions';
-import { EvalScoreBadge, SkillEvaluationDetails } from '@/experiences/SkillEvaluation';
+import { SkillEvaluationDetails } from '@/experiences/SkillEvaluation';
 import { buildSkillDeeplink } from '@/utils/skillDeeplink';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
@@ -50,7 +50,6 @@ export const SkillInfo: React.FC = () => {
       metadata={
         <>
           <Badge appearance="filled" color="brand" shape="circular">Skill</Badge>
-          <EvalScoreBadge evalResult={evalResult.data} />
           {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </>
       }
@@ -83,8 +82,7 @@ export const SkillInfo: React.FC = () => {
         skillSourceUrl ? (
           <HeaderActions showExtensionHint>
             <Button
-              appearance="primary"
-              icon={<ArrowDownloadRegular />}
+              icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
               onClick={handleSkillInstall}
             >
               Install in VS Code

--- a/src/utils/badgeSystem.ts
+++ b/src/utils/badgeSystem.ts
@@ -1,0 +1,31 @@
+import type { BadgeProps } from '@fluentui/react-components';
+
+/**
+ * Badge design system — consistent visual hierarchy across all pages.
+ *
+ * Tier 1 – Identity:  filled / brand / circular   (MCP, API, Agent…)
+ * Tier 2 – Sub-type:  tint   / brand / circular   (REST, GraphQL…)
+ * Tier 3 – Lifecycle: tint   / semantic / circular  (production → success, preview → warning…)
+ * Tier 4 – Transport: tint   / brand / circular    (Local, Remote, Local + Remote — same as sub-type)
+ * Tier 5 – Tags:      tint   / informative / circular (user custom properties)
+ */
+
+type SemanticColor = NonNullable<BadgeProps['color']>;
+
+const LIFECYCLE_COLORS: Record<string, SemanticColor> = {
+  production: 'success',
+  ga: 'success',
+  stable: 'success',
+  preview: 'brand',
+  beta: 'brand',
+  testing: 'brand',
+  deprecated: 'severe',
+  retired: 'danger',
+  development: 'informative',
+  design: 'informative',
+};
+
+export function getLifecycleBadgeColor(stage?: string): SemanticColor {
+  if (!stage) return 'informative';
+  return LIFECYCLE_COLORS[stage.toLowerCase()] ?? 'informative';
+}


### PR DESCRIPTION
## Changes

### P0 — MCP asset experience
- **Hide test console** from local-only MCP servers (no remote endpoint to connect to)
- **Add Local / Remote / Local + Remote badges** on MCP detail page, positioned right after the MCP identity pill

### Badge system audit (12 files)
- **Unified shape**: all badges now use `circular` — no more mixed `rounded` vs `circular`
- **Semantic lifecycle colors**: production → green, preview/testing → blue, deprecated → orange, retired → red
- **Fixed yellow tint a11y**: `warning` tint had poor contrast on white — preview/testing now use `brand` blue
- **Impact tags**: converted custom CSS `<span>` to proper Fluent `<Badge>` components
- **Skill install button**: changed from blue primary to white + VS Code icon (matching MCP)
- **Removed redundant score badge** from Skill header metadata (already visible on Assessment tab)
- **Tag icon**: added `TagRegular` icon before custom property pills
- **Created `badgeSystem.ts`**: shared lifecycle color mapping utility

<img width="709" height="338" alt="Screenshot 2026-05-12 at 11 45 49 AM" src="https://github.com/user-attachments/assets/b677adf9-06f8-4825-9dfb-c3110e0e6301" />
<img width="1569" height="791" alt="Screenshot 2026-05-12 at 11 45 17 AM" src="https://github.com/user-attachments/assets/c8f375a5-0a78-4fb6-9002-988f6fb16c5a" />



---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*