### PR TITLE
Rename model playground route to /models/:name

### DIFF
--- a/.wiki/routing.md
+++ b/.wiki/routing.md
@@ -16,7 +16,7 @@ The application uses **React Router DOM v6** (`createBrowserRouter`) for client-
 | `/skills/:name` | `SkillInfo` | `Layout` | Skill detail page |
 | `/plugins/:name` | `PluginInfo` | `Layout` | Plugin detail page |
 | `/agents/:name` | `AgentChat` | `Layout` | Agent conversational UI |
-| `/languageModels/:name/playground` | `ModelPlayground` | `Layout` | Interactive model playground |
+| `/models/:name` | `ModelPlayground` | `Layout` | Interactive model test console |
 
 ### Route Hierarchy (tree view)
 
@@ -28,7 +28,7 @@ Layout
 ├── /skills/:name ................................ SkillInfo
 ├── /plugins/:name ............................... PluginInfo
 ├── /agents/:name ................................ AgentChat
-└── /languageModels/:name/playground ............. ModelPlayground
+└── /models/:name ................................ ModelPlayground
 ```
 
 ---
@@ -56,7 +56,7 @@ Layout
 - **Component**: `src/pages/ModelInfo/ModelInfo.tsx`
 - **Purpose**: Side drawer showing language model details — provider, model name, context window, task/input/output types, playground link, contacts, and documentation.
 - **Asset identifier**: `name` — language model name
-- **Nuances**: Same nested-drawer pattern as `ApiInfo`. The playground button navigates to `/languageModels/:name/playground`. Does not show version/definition selectors.
+- **Nuances**: Same nested-drawer pattern as `ApiInfo`. The test console button navigates to `/models/:name`. Does not show version/definition selectors.
 
 ### ApiSpec — APIs (`/apis/:apiName/versions/:versionName/definitions/:definitionName`)
 
@@ -98,10 +98,10 @@ Layout
 - **Purpose**: Conversational chat UI for an agent-type API.
 - **Route param**: `:name`
 
-### ModelPlayground (`/languageModels/:name/playground`)
+### ModelPlayground (`/models/:name`)
 
 - **Component**: `src/pages/ModelPlayground/ModelPlayground.tsx`
-- **Purpose**: Interactive playground for sending messages to a language model and viewing responses.
+- **Purpose**: Interactive test console for sending messages to a language model and viewing responses.
 - **Route param**: `:name`
 
 ---
@@ -117,7 +117,7 @@ All internal URL construction is centralized in `src/services/LocationsService.t
 | `getSkillInfoUrl(name)` | `/skills/{name}` | |
 | `getPluginInfoUrl(name)` | `/plugins/{name}` | |
 | `getAgentChatUrl(name)` | `/agents/{name}` | |
-| `getModelPlaygroundUrl(name)` | `/languageModels/{name}/playground` | |
+| `getModelPlaygroundUrl(name)` | `/models/{name}` | |
 | `getApiSchemaExplorerUrl(api, version, definition, resourceType?)` | `/{resourceType}/{api}/versions/{version}/definitions/{definition}` | Uses the asset-type route segment for browser navigation |
 | `getAiSearchInfoUrl()` | External docs link | |
 | `getHelpUrl()` | External docs link | |
@@ -140,7 +140,7 @@ This applies to the related model endpoints as well:
 
 - UI spec route: `/languageModels/chat-gpt/versions/{version}/definitions/{definition}`
 - Data API spec request: `/apis/chat-gpt/versions/{version}/definitions/{definition}`
-- UI playground route: `/languageModels/chat-gpt/playground`
+- UI test console route: `/models/chat-gpt`
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
             element: <ModelDetailPage />,
           },
           {
-            path: 'languageModels/:name/playground',
+            path: 'models/:name',
             element: <ModelPlayground />,
           },
           {

--- a/src/pages/ModelPlayground/ModelPlayground.tsx
+++ b/src/pages/ModelPlayground/ModelPlayground.tsx
@@ -221,7 +221,7 @@ export const ModelPlayground: React.FC = () => {
       <section className={styles.tabBar}>
         <TabList selectedValue={activeTab} onTabSelect={(_, data) => setActiveTab(data.value as PlaygroundTabs)}>
           <Tab icon={<DocumentRegular />} value={PlaygroundTabs.DOCUMENTATION}>Documentation</Tab>
-          {runtimeUrl && <Tab icon={<ChatRegular />} value={PlaygroundTabs.PLAYGROUND}>Model playground</Tab>}
+          {runtimeUrl && <Tab icon={<ChatRegular />} value={PlaygroundTabs.PLAYGROUND}>Test console</Tab>}
         </TabList>
       </section>
 

--- a/src/services/LocationsService.ts
+++ b/src/services/LocationsService.ts
@@ -52,7 +52,7 @@ export const LocationsService = {
   },
 
   getModelPlaygroundUrl(name: string): string {
-    return `/languageModels/${name}/playground`;
+    return `/models/${name}`;
   },
 
   getApiSchemaExplorerUrl(


### PR DESCRIPTION
## Summary

Renames the model playground route from `/languageModels/:name/playground` to `/models/:name`.

## Changes

- `src/App.tsx` — route path updated to `models/:name`
- `src/services/LocationsService.ts` — `getModelPlaygroundUrl` now returns `/models/{name}`
- `src/pages/ModelPlayground/ModelPlayground.tsx` — tab label renamed from `Model playground` to `Test console`
- `.wiki/routing.md` — route map, tree view, helper table, and `ModelPlayground` section synced to the new path

## Notes

- `getModelPlaygroundUrl` is preserved as the helper name to avoid touching existing call sites (e.g. `ApiList.tsx`).
- The model detail page route `/languageModels/:apiName` is unchanged; only the test console route was renamed.