### PR TITLE
Extract MCP server detail page to /servers/:apiName

### DIFF
--- a/.github/skills/design/SKILL.md
+++ b/.github/skills/design/SKILL.md
@@ -14,7 +14,7 @@ description: "Design rules and conventions for the API Center Portal. Use when e
 
 ## Navigation
 
-- **All cards navigate to full pages.** API cards go to `/apis/:name`, MCP cards go to `/apis/:name`, model cards go to `/languageModels/:name`. Never open a side panel/drawer from a card click.
+- **All cards navigate to full pages.** API cards go to `/apis/:name`, MCP cards go to `/servers/:name`, model cards go to `/languageModels/:name`. Never open a side panel/drawer from a card click.
 - **No playground routes.** The model playground feature is removed. Do not add "Open in playground" buttons or links, and do not route to `/languageModels/:name/playground`.
 - The `useDesignVariation` hook should NOT be used to toggle between drawer and full-page navigation — full pages are always used.
 

--- a/.wiki/routing.md
+++ b/.wiki/routing.md
@@ -11,6 +11,8 @@ The application uses **React Router DOM v6** (`createBrowserRouter`) for client-
 | Path | Component | Parent | Purpose |
 |------|-----------|--------|---------|
 | `/` | `Home` | `Layout` | Landing page with search, filters, and API/model catalog |
+| `/apis/:apiName` | `ApiDetailPage` | `Layout` | Detail page for APIs (REST, GraphQL, gRPC, SOAP, plugin/skill/agent/model render via their own pages or detail layout) |
+| `/servers/:apiName` | `McpServerDetailPage` | `Layout` | Detail page for MCP servers |
 | `/apis/:apiName/versions/:versionName/definitions/:definitionName` | `ApiSpec` | `Layout` | Spec explorer for regular APIs |
 | `/languageModels/:apiName/versions/:versionName/definitions/:definitionName` | `ApiSpec` | `Layout` | Spec explorer for language models |
 | `/skills/:name` | `SkillInfo` | `Layout` | Skill detail page |
@@ -23,6 +25,8 @@ The application uses **React Router DOM v6** (`createBrowserRouter`) for client-
 ```
 Layout
 ├── / ............................................. Home (catalog + search)
+├── /apis/:apiName ................................ ApiDetailPage
+├── /servers/:apiName ............................. McpServerDetailPage
 ├── /apis/:apiName/versions/:versionName/definitions/:definitionName .... ApiSpec
 ├── /languageModels/:apiName/versions/:versionName/definitions/:definitionName .... ApiSpec
 ├── /skills/:name ................................ SkillInfo
@@ -98,6 +102,13 @@ Layout
 - **Purpose**: Conversational chat UI for an agent-type API.
 - **Route param**: `:name`
 
+### McpServerDetailPage (`/servers/:apiName`)
+
+- **Component**: `src/pages/McpServerDetailPage/McpServerDetailPage.tsx`
+- **Purpose**: Full-page detail view for an MCP server, including local/remote install actions and a test console tab.
+- **Route param**: `:apiName`
+- **Nuance**: MCP servers no longer share the `/apis/:apiName` route; cards on the catalog navigate here via `getMcpServerUrl(name)`.
+
 ### ModelPlayground (`/models/:name`)
 
 - **Component**: `src/pages/ModelPlayground/ModelPlayground.tsx`
@@ -117,6 +128,7 @@ All internal URL construction is centralized in `src/services/LocationsService.t
 | `getSkillInfoUrl(name)` | `/skills/{name}` | |
 | `getPluginInfoUrl(name)` | `/plugins/{name}` | |
 | `getAgentChatUrl(name)` | `/agents/{name}` | |
+| `getMcpServerUrl(name)` | `/servers/{name}` | |
 | `getModelPlaygroundUrl(name)` | `/models/{name}` | |
 | `getApiSchemaExplorerUrl(api, version, definition, resourceType?)` | `/{resourceType}/{api}/versions/{version}/definitions/{definition}` | Uses the asset-type route segment for browser navigation |
 | `getAiSearchInfoUrl()` | External docs link | |
@@ -155,6 +167,7 @@ Clicking an item in the API list navigates based on its `kind` (via `apiAdapter`
 | `'agent'` | `/agents/{name}` | `getAgentChatUrl` |
 | `'skill'` | `/skills/{name}` | `getSkillInfoUrl` |
 | `'plugin'` | `/plugins/{name}` | `getPluginInfoUrl` |
+| `'mcp'` | `/servers/{name}` | `getMcpServerUrl` |
 | `'languageModel'` | Home drawer for `{name}` | Home navigation state |
 | anything else | Home drawer for `{name}` | Home navigation state |
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SkillInfo from '@/pages/SkillInfo';
 import PluginInfo from '@/pages/PluginInfo';
 import AgentInfo from '@/pages/AgentInfo';
 import ApiDetailPage from '@/pages/ApiDetailPage';
+import McpServerDetailPage from '@/pages/McpServerDetailPage';
 import ModelDetailPage from '@/pages/ModelDetailPage';
 import { ModelPlayground } from '@/pages/ModelPlayground';
 import { configAtom } from '@/atoms/configAtom';
@@ -32,6 +33,10 @@ const App: React.FC = () => {
           {
             path: 'apis/:apiName',
             element: <ApiDetailPage />,
+          },
+          {
+            path: 'servers/:apiName',
+            element: <McpServerDetailPage />,
           },
           {
             path: 'languageModels/:apiName',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,10 +51,6 @@ const App: React.FC = () => {
             element: <ApiSpec />,
           },
           {
-            path: 'languageModels/:apiName/versions/:versionName/definitions/:definitionName',
-            element: <ApiSpec />,
-          },
-          {
             path: 'skills/:name',
             element: <SkillInfo />,
           },

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -53,6 +53,7 @@ export const ApiList: React.FC = () => {
       if (kind === 'agent') return LocationsService.getAgentInfoUrl(api.name);
       if (kind === 'skill') return LocationsService.getSkillInfoUrl(api.name);
       if (kind === 'plugin') return LocationsService.getPluginInfoUrl(api.name);
+      if (kind === 'mcp') return LocationsService.getMcpServerUrl(api.name);
       if (kind === 'languagemodel') return LocationsService.getModelPlaygroundUrl(api.name);
       return LocationsService.getApiDetailUrl(api.name);
     },

--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Button, Dropdown, Link, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Option, SplitButton, Spinner, Tab, TabList } from '@fluentui/react-components';
-import { ArrowDownloadRegular, DocumentRegular, ListRegular, TagRegular, WindowConsoleRegular } from '@fluentui/react-icons';
-import { useRecoilValue } from 'recoil';
+import { Badge, Button, Dropdown, Link, Option, Tab, TabList } from '@fluentui/react-components';
+import { ArrowDownloadRegular, DocumentRegular, ListRegular, TagRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
-import { useServer } from '@/hooks/useServer';
-import { configAtom } from '@/atoms/configAtom';
 import { kindToResourceType, ApiDefinitionId } from '@/types/apiDefinition';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout, BreadcrumbItem } from '@/components/DetailPageLayout/DetailPageLayout';
@@ -19,11 +16,11 @@ import { useApiSpec } from '@/hooks/useApiSpec';
 import { useApiSpecUrl } from '@/hooks/useApiSpecUrl';
 import { useApiDefinitions } from '@/hooks/useApiDefinitions';
 import ApiSpecPageLayout from '@/pages/ApiSpec/ApiSpecPageLayout';
-import McpSpecPage from '@/pages/ApiSpec/McpSpecPage';
 import EmptyStateMessage from '@/components/EmptyStateMessage';
-import { ConnectPanel } from '@/components/ConnectPanel';
-import MarkdownRenderer from '@/components/MarkdownRenderer';
+import { useRecoilValue } from 'recoil';
+import { configAtom } from '@/atoms/configAtom';
 import { InstallationBlock } from '@/components/InstallationBlock';
+import { Spinner } from '@fluentui/react-components';
 import VsCodeLogo from '@/assets/vsCodeLogo.svg';
 
 export const ApiDetailPage: React.FC = () => {
@@ -36,12 +33,12 @@ export const ApiDetailPage: React.FC = () => {
   setDocumentTitle(`API${api.data?.title ? ` - ${api.data.title}` : ''}`);
 
   const kind = api.data?.kind;
-  const STANDALONE_KINDS = ['skill', 'a2a', 'mcp', 'plugin', 'agent', 'languagemodel'];
+  const STANDALONE_KINDS = ['skill', 'a2a', 'plugin', 'agent', 'languagemodel'];
   const isStandaloneKind = kind ? STANDALONE_KINDS.includes(kind.toLowerCase()) : false;
   const categoryLabel = isStandaloneKind ? formatKindDisplay(kind!) : 'API';
 
   const CATEGORY_PLURALS: Record<string, string> = {
-    mcp: 'MCP servers', rest: 'APIs', graphql: 'APIs', grpc: 'APIs', soap: 'APIs',
+    rest: 'APIs', graphql: 'APIs', grpc: 'APIs', soap: 'APIs',
     skill: 'Skills', plugin: 'Plugins', agent: 'Agents', a2a: 'Agents', languagemodel: 'Models',
   };
   const breadcrumbs = useMemo<BreadcrumbItem[]>(() => {
@@ -53,11 +50,9 @@ export const ApiDetailPage: React.FC = () => {
     ];
   }, [kind, api.data?.title, apiName]);
 
-  const hiddenSelects = ['mcp', 'skill', 'plugin'].includes(kind ?? '')
+  const hiddenSelects = ['skill', 'plugin'].includes(kind ?? '')
     ? (['definition', 'deployment'] as Array<keyof ApiDefinitionSelection>)
     : (['definition'] as Array<keyof ApiDefinitionSelection>);
-
-  const server = useServer(kind === 'mcp' ? apiName : undefined);
 
   const skillSourceUrl = useMemo(
     () => api.data?.customProperties?.['sourceUrl'] as string | undefined,
@@ -87,43 +82,6 @@ export const ApiDetailPage: React.FC = () => {
     return tags;
   }, [api.data?.customProperties]);
 
-  // MCP install
-  const hasRemoteInstall = kind === 'mcp' && !!definitionSelection?.deployment?.server.runtimeUri.length;
-  const hasLocalInstall = kind === 'mcp' && !!server.data?.packages;
-  const hasMcpInstall = hasRemoteInstall || hasLocalInstall;
-
-  const handleMcpInstall = useCallback((target?: 'remote' | 'local') => {
-    const useRemote = target ? target === 'remote' : hasRemoteInstall;
-    const baseName = api.data?.title || apiName || '';
-
-    if (useRemote && hasRemoteInstall) {
-      const runtimeUri = definitionSelection?.deployment?.server.runtimeUri[0];
-      if (!runtimeUri) return;
-      const matchingRemote = server.data?.remotes?.find((r) => r.url === runtimeUri);
-      const transportType = matchingRemote?.transport_type || 'sse';
-      const payload = {
-        name: hasLocalInstall ? `${baseName} (remote)` : baseName,
-        type: transportType,
-        url: runtimeUri,
-      };
-      window.open(`vscode:mcp/install?${encodeURIComponent(JSON.stringify(payload))}`);
-    } else if (hasLocalInstall) {
-      const [pkg] = server.data!.packages!;
-      if (!pkg) return;
-      const runtimeArgs = (pkg.runtimeArguments ?? []).map((arg: { value?: string }) => arg.value).filter(Boolean);
-      const packageRef = pkg.version ? `${pkg.identifier}@${pkg.version}` : pkg.identifier;
-      const args = pkg.runtimeHint === 'npx' ? ['-y', packageRef, ...runtimeArgs] : runtimeArgs;
-      const localBase = baseName || pkg.identifier.split('/').pop() || pkg.identifier;
-      const payload = {
-        name: hasRemoteInstall ? `${localBase} (local)` : localBase,
-        type: pkg.transport?.type || 'stdio',
-        command: pkg.runtimeHint,
-        args,
-      };
-      window.open(`vscode:mcp/install?${encodeURIComponent(JSON.stringify(payload))}`);
-    }
-  }, [api.data?.title, apiName, definitionSelection?.deployment?.server.runtimeUri, server.data, hasRemoteInstall, hasLocalInstall]);
-
   // Skill install
   const handleSkillInstall = useCallback(() => {
     if (!skillSourceUrl || !api.data?.name) return;
@@ -131,26 +89,17 @@ export const ApiDetailPage: React.FC = () => {
     window.open(deeplink);
   }, [skillSourceUrl, api.data?.name]);
 
-  const hasInstall = hasMcpInstall || (kind === 'skill' && !!skillSourceUrl);
+  const hasInstall = kind === 'skill' && !!skillSourceUrl;
 
   // Copyable endpoint URL for devs to use in CLI / other tools
   const endpointUrl = useMemo(() => {
-    // MCP: prefer deployment runtimeUri, fall back to server remotes
-    if (kind === 'mcp') {
-      const deploymentUri = definitionSelection?.deployment?.server.runtimeUri[0];
-      if (deploymentUri) return deploymentUri;
-      const remoteUrl = server.data?.remotes?.[0]?.url;
-      if (remoteUrl) return remoteUrl;
-    }
     // Skill: sourceUrl from custom properties
     if (kind === 'skill' && skillSourceUrl) return skillSourceUrl;
     // General APIs: runtimeUri from deployment
     const deploymentUri = definitionSelection?.deployment?.server.runtimeUri[0];
     if (deploymentUri) return deploymentUri;
     return undefined;
-  }, [kind, definitionSelection?.deployment?.server.runtimeUri, server.data?.remotes, skillSourceUrl]);
-
-  const isMcp = kind === 'mcp';
+  }, [kind, definitionSelection?.deployment?.server.runtimeUri, skillSourceUrl]);
 
   const hasCustomProps = !!Object.keys(api.data?.customProperties || {}).length;
   const hasExternalDocs = !!api.data?.externalDocumentation?.filter(d => !!d.title && d.url).length;
@@ -201,15 +150,6 @@ export const ApiDetailPage: React.FC = () => {
 
   function renderInstallationBlock() {
     const kindLower = kind?.toLowerCase();
-    if (kindLower === 'mcp' && endpointUrl) {
-      return (
-        <InstallationBlock
-          assetType="mcp"
-          endpointUrl={endpointUrl}
-          assetName={api.data?.name || apiName || 'mcp-server'}
-        />
-      );
-    }
     if (kindLower === 'plugin') {
       return (
         <InstallationBlock
@@ -233,18 +173,6 @@ export const ApiDetailPage: React.FC = () => {
 
   function renderDocumentation() {
     if (!definitionId) return null;
-
-    if (isMcp) {
-      if (!definitionSelection?.deployment) {
-        return <Spinner size="small" label="Loading documentation..." labelPosition="below" />;
-      }
-      return (
-        <McpSpecPage
-          definitionId={definitionId}
-          deployment={definitionSelection.deployment}
-        />
-      );
-    }
 
     if (apiSpec.isLoading) {
       return <Spinner size="small" label="Loading documentation..." labelPosition="below" />;
@@ -278,15 +206,6 @@ export const ApiDetailPage: React.FC = () => {
               {formatKindDisplay(kind)}
             </Badge>
           )}
-          {isMcp && hasLocalInstall && hasRemoteInstall && (
-            <Badge appearance="tint" color="brand" shape="circular">Local + Remote</Badge>
-          )}
-          {isMcp && hasLocalInstall && !hasRemoteInstall && (
-            <Badge appearance="tint" color="brand" shape="circular">Local</Badge>
-          )}
-          {isMcp && !hasLocalInstall && hasRemoteInstall && (
-            <Badge appearance="tint" color="brand" shape="circular">Remote</Badge>
-          )}
           {api.data?.lifecycleStage && (
             <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
               {api.data.lifecycleStage}
@@ -308,8 +227,7 @@ export const ApiDetailPage: React.FC = () => {
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
           <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
-          {isMcp && hasRemoteInstall && <Tab icon={<WindowConsoleRegular />} value="testconsole">Test console</Tab>}
-          {!isMcp && hasAdditionalInfo && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
+          {hasAdditionalInfo && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
         </TabList>
       }
       selector={
@@ -365,7 +283,7 @@ export const ApiDetailPage: React.FC = () => {
           <HeaderActions showExtensionHint>
             <Button
               icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
-              onClick={hasMcpInstall ? () => handleMcpInstall() : handleSkillInstall}
+              onClick={handleSkillInstall}
             >
               Install in VS Code
             </Button>
@@ -379,22 +297,11 @@ export const ApiDetailPage: React.FC = () => {
       sidebar={undefined}
     >
       {api.data && selectedTab === 'documentation' && (
-        isMcp ? (
-          <>
-            {renderInstallationBlock()}
-            {api.data.description && api.data.description !== api.data.summary && (
-              <MarkdownRenderer markdown={api.data.description} />
-            )}
-            <ApiAdditionalInfo api={api.data} />
-          </>
-        ) : (
-          <>
-            {renderInstallationBlock()}
-            {renderDocumentation()}
-          </>
-        )
+        <>
+          {renderInstallationBlock()}
+          {renderDocumentation()}
+        </>
       )}
-      {api.data && selectedTab === 'testconsole' && isMcp && hasRemoteInstall && renderDocumentation()}
       {api.data && selectedTab === 'properties' && (
         <ApiAdditionalInfo api={api.data} />
       )}

--- a/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
+++ b/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Badge, Button, Spinner, Tab, TabList } from '@fluentui/react-components';
+import { DocumentRegular, TagRegular, WindowConsoleRegular } from '@fluentui/react-icons';
+import { useApi } from '@/hooks/useApi';
+import { useServer } from '@/hooks/useServer';
+import { kindToResourceType, ApiDefinitionId } from '@/types/apiDefinition';
+import { setDocumentTitle } from '@/utils/dom';
+import { DetailPageLayout, BreadcrumbItem } from '@/components/DetailPageLayout/DetailPageLayout';
+import ApiDefinitionSelect, { ApiDefinitionSelection } from '@/experiences/ApiDefinitionSelect';
+import ApiAdditionalInfo from '@/experiences/ApiAdditionalInfo';
+import { HeaderActions } from '@/experiences/HeaderActions';
+import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import McpSpecPage from '@/pages/ApiSpec/McpSpecPage';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import { InstallationBlock } from '@/components/InstallationBlock';
+import VsCodeLogo from '@/assets/vsCodeLogo.svg';
+
+export const McpServerDetailPage: React.FC = () => {
+  const { apiName } = useParams<{ apiName: string }>();
+  const api = useApi(apiName);
+  const [definitionSelection, setDefinitionSelection] = useState<ApiDefinitionSelection | undefined>();
+  const [selectedTab, setSelectedTab] = useState<string>('documentation');
+
+  setDocumentTitle(`MCP server${api.data?.title ? ` - ${api.data.title}` : ''}`);
+
+  const kind = api.data?.kind;
+
+  const breadcrumbs = useMemo<BreadcrumbItem[]>(() => [
+    { label: 'Home', href: '/' },
+    { label: 'MCP servers', href: '/?kind=mcp' },
+    { label: api.data?.title || apiName || '...' },
+  ], [api.data?.title, apiName]);
+
+  const hiddenSelects = ['definition', 'deployment'] as Array<keyof ApiDefinitionSelection>;
+
+  const server = useServer(apiName);
+
+  const customPropertyTags = useMemo(() => {
+    const props = api.data?.customProperties;
+    if (!props) return [];
+    const tags: string[] = [];
+    const skip = new Set(['sourceUrl']);
+    for (const [key, val] of Object.entries(props)) {
+      if (skip.has(key)) continue;
+      if (typeof val === 'string') {
+        val.split(',').forEach(t => {
+          const trimmed = t.trim();
+          if (trimmed && trimmed.length <= 50 && !/^https?:\/\//.test(trimmed) && !/^[0-9a-f-]{36}$/i.test(trimmed)) {
+            tags.push(trimmed);
+          }
+        });
+      } else if (Array.isArray(val)) {
+        val.forEach(item => {
+          if (typeof item === 'string' && item.trim() && item.trim().length <= 50) tags.push(item.trim());
+        });
+      }
+    }
+    return tags;
+  }, [api.data?.customProperties]);
+
+  const hasRemoteInstall = !!definitionSelection?.deployment?.server.runtimeUri.length;
+  const hasLocalInstall = !!server.data?.packages;
+  const hasInstall = hasRemoteInstall || hasLocalInstall;
+
+  const handleMcpInstall = useCallback((target?: 'remote' | 'local') => {
+    const useRemote = target ? target === 'remote' : hasRemoteInstall;
+    const baseName = api.data?.title || apiName || '';
+
+    if (useRemote && hasRemoteInstall) {
+      const runtimeUri = definitionSelection?.deployment?.server.runtimeUri[0];
+      if (!runtimeUri) return;
+      const matchingRemote = server.data?.remotes?.find((r) => r.url === runtimeUri);
+      const transportType = matchingRemote?.transport_type || 'sse';
+      const payload = {
+        name: hasLocalInstall ? `${baseName} (remote)` : baseName,
+        type: transportType,
+        url: runtimeUri,
+      };
+      window.open(`vscode:mcp/install?${encodeURIComponent(JSON.stringify(payload))}`);
+    } else if (hasLocalInstall) {
+      const [pkg] = server.data!.packages!;
+      if (!pkg) return;
+      const runtimeArgs = (pkg.runtimeArguments ?? []).map((arg: { value?: string }) => arg.value).filter(Boolean);
+      const packageRef = pkg.version ? `${pkg.identifier}@${pkg.version}` : pkg.identifier;
+      const args = pkg.runtimeHint === 'npx' ? ['-y', packageRef, ...runtimeArgs] : runtimeArgs;
+      const localBase = baseName || pkg.identifier.split('/').pop() || pkg.identifier;
+      const payload = {
+        name: hasRemoteInstall ? `${localBase} (local)` : localBase,
+        type: pkg.transport?.type || 'stdio',
+        command: pkg.runtimeHint,
+        args,
+      };
+      window.open(`vscode:mcp/install?${encodeURIComponent(JSON.stringify(payload))}`);
+    }
+  }, [api.data?.title, apiName, definitionSelection?.deployment?.server.runtimeUri, server.data, hasRemoteInstall, hasLocalInstall]);
+
+  // Copyable endpoint URL for devs to use in CLI / other tools
+  const endpointUrl = useMemo(() => {
+    const deploymentUri = definitionSelection?.deployment?.server.runtimeUri[0];
+    if (deploymentUri) return deploymentUri;
+    const remoteUrl = server.data?.remotes?.[0]?.url;
+    if (remoteUrl) return remoteUrl;
+    return undefined;
+  }, [definitionSelection?.deployment?.server.runtimeUri, server.data?.remotes]);
+
+  const definitionId = useMemo<ApiDefinitionId | undefined>(() => {
+    if (!apiName || !definitionSelection?.version?.name || !definitionSelection?.definition?.name) return undefined;
+    return {
+      apiName,
+      versionName: definitionSelection.version.name,
+      definitionName: definitionSelection.definition.name,
+      resourceType: kindToResourceType(kind),
+    };
+  }, [apiName, definitionSelection?.version?.name, definitionSelection?.definition?.name, kind]);
+
+  function renderInstallationBlock() {
+    if (!endpointUrl) return null;
+    return (
+      <InstallationBlock
+        assetType="mcp"
+        endpointUrl={endpointUrl}
+        assetName={api.data?.name || apiName || 'mcp-server'}
+      />
+    );
+  }
+
+  function renderTestConsole() {
+    if (!definitionId) return null;
+    if (!definitionSelection?.deployment) {
+      return <Spinner size="small" label="Loading documentation..." labelPosition="below" />;
+    }
+    return (
+      <McpSpecPage
+        definitionId={definitionId}
+        deployment={definitionSelection.deployment}
+      />
+    );
+  }
+
+  return (
+    <DetailPageLayout
+      title={api.data?.title}
+      summary={api.data?.summary}
+      breadcrumbs={breadcrumbs}
+      metadata={
+        <>
+          <Badge appearance="filled" color="brand" shape="circular">
+            MCP
+          </Badge>
+          {hasLocalInstall && hasRemoteInstall && (
+            <Badge appearance="tint" color="brand" shape="circular">Local + Remote</Badge>
+          )}
+          {hasLocalInstall && !hasRemoteInstall && (
+            <Badge appearance="tint" color="brand" shape="circular">Local</Badge>
+          )}
+          {!hasLocalInstall && hasRemoteInstall && (
+            <Badge appearance="tint" color="brand" shape="circular">Remote</Badge>
+          )}
+          {api.data?.lifecycleStage && (
+            <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
+              {api.data.lifecycleStage}
+            </Badge>
+          )}
+          {customPropertyTags.length > 0 && (
+            <>
+              <TagRegular style={{ fontSize: 16, color: 'var(--colorNeutralForeground3)', flexShrink: 0 }} />
+              {customPropertyTags.map(tag => (
+                <Badge key={tag} appearance="tint" color="informative" shape="circular">
+                  {tag}
+                </Badge>
+              ))}
+            </>
+          )}
+          {api.data?.lastUpdated && <span>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
+        </>
+      }
+      tabs={
+        <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
+          <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
+          {hasRemoteInstall && <Tab icon={<WindowConsoleRegular />} value="testconsole">Test console</Tab>}
+        </TabList>
+      }
+      selector={
+        apiName && api.data ? (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: '24px', flexWrap: 'wrap' }}>
+            <ApiDefinitionSelect
+              apiId={apiName}
+              resourceType={kindToResourceType(api.data.kind)}
+              hiddenSelects={hiddenSelects}
+              isInline
+              onSelectionChange={setDefinitionSelection}
+            />
+          </div>
+        ) : undefined
+      }
+      headerActions={
+        hasInstall ? (
+          <HeaderActions showExtensionHint>
+            <Button
+              icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
+              onClick={() => handleMcpInstall()}
+            >
+              Install in VS Code
+            </Button>
+          </HeaderActions>
+        ) : undefined
+      }
+      isLoading={api.isLoading}
+      error={api.isError ? 'Failed to load MCP server details. Please check your connection and try again.' : undefined}
+      onRetry={() => api.refetch()}
+      emptyMessage={!api.isLoading && !api.isError && !api.data ? 'The specified MCP server does not exist.' : undefined}
+      sidebar={undefined}
+    >
+      {api.data && selectedTab === 'documentation' && (
+        <>
+          {renderInstallationBlock()}
+          {api.data.description && api.data.description !== api.data.summary && (
+            <MarkdownRenderer markdown={api.data.description} />
+          )}
+          <ApiAdditionalInfo api={api.data} />
+        </>
+      )}
+      {api.data && selectedTab === 'testconsole' && hasRemoteInstall && renderTestConsole()}
+    </DetailPageLayout>
+  );
+};
+
+export default React.memo(McpServerDetailPage);

--- a/src/pages/McpServerDetailPage/index.ts
+++ b/src/pages/McpServerDetailPage/index.ts
@@ -1,0 +1,2 @@
+export { McpServerDetailPage as default } from './McpServerDetailPage';
+export { McpServerDetailPage } from './McpServerDetailPage';

--- a/src/services/LocationsService.ts
+++ b/src/services/LocationsService.ts
@@ -39,6 +39,10 @@ export const LocationsService = {
     return `/apis/${name}`;
   },
 
+  getMcpServerUrl(name: string): string {
+    return `/servers/${name}`;
+  },
+
   getModelDetailUrl(name: string): string {
     return `/languageModels/${name}`;
   },


### PR DESCRIPTION
## Summary

Extracts the MCP server detail UI from `ApiDetailPage` into its own page and route at `/servers/:apiName`. MCP cards in the catalog now navigate to this dedicated page instead of being handled as a special case inside the generic API detail page.

> Based on `route/models-test-console` (#118). The first commit is from that PR; the changes specific to this PR start at the second commit.

## Changes

- **New page**: `src/pages/McpServerDetailPage/` — owns badges, install actions, test console tab, and `McpSpecPage` rendering for MCP servers.
- **New route**: `/servers/:apiName` → `McpServerDetailPage` added in `src/App.tsx`.
- **New URL helper**: `LocationsService.getMcpServerUrl(name)` returns `/servers/{name}`.
- **Card navigation**: `ApiList.tsx` now routes `kind === 'mcp'` cards to `getMcpServerUrl(api.name)`.
- **ApiDetailPage cleanup**: All MCP-specific branches removed — `useServer`, `McpSpecPage`, `handleMcpInstall`, MCP badges, the dedicated "Test console" tab, and the MCP rendering branch are gone. Imports trimmed accordingly.
- **Docs**: `.wiki/routing.md` route map, tree, helper table, catalog navigation table, and new `McpServerDetailPage` section. `design/SKILL.md` MCP card navigation rule updated to `/servers/:name`.

## Notes

- `McpServerDetailPage` is a near-copy of the MCP portions of `ApiDetailPage`, intentionally — no shared helper extracted yet to keep the diff focused.
- The data plane is unchanged (`McpService`, `useServer`, etc. all still hit `/apis/{name}` / `/v0/servers/{name}` as before).
- `/apis/:apiName` still resolves; if anyone navigates there with an MCP-kind asset directly, it will load via `ApiDetailPage` but render only the generic API tabs (no install/test console). External links should use `/servers/:name`.
