### PR TITLE
feat: MCP transport tags (Local/Remote) + title-case lifecycle badges

### DIFF
--- a/src/components/ApiCard/ApiCard.tsx
+++ b/src/components/ApiCard/ApiCard.tsx
@@ -16,6 +16,7 @@ interface Props {
   api: ApiCardApi;
   onClick?: (e: React.MouseEvent) => void;
   showType?: boolean;
+  transportTags?: string[];
 }
 
 const STANDALONE_KINDS = ['skill', 'a2a', 'mcp', 'plugin', 'agent', 'languagemodel'];
@@ -55,7 +56,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const ApiCard: React.FC<Props> = ({ api, showType, onClick }) => {
+export const ApiCard: React.FC<Props> = ({ api, showType, onClick, transportTags }) => {
   const classes = useStyles();
   const hasScore = api.evalScore != null && api.evalMaxScore != null && api.evalMaxScore > 0;
   const scoreRatio = hasScore ? api.evalScore! / api.evalMaxScore! : 0;
@@ -74,6 +75,9 @@ export const ApiCard: React.FC<Props> = ({ api, showType, onClick }) => {
           {!!api.type && !STANDALONE_KINDS.includes(api.type.toLowerCase()) && (
             <Badge appearance="tint" color="brand" shape="circular">{formatKindDisplay(api.type)}</Badge>
           )}
+          {transportTags?.map((tag) => (
+            <Badge key={tag} appearance="tint" color="brand" shape="circular">{tag}</Badge>
+          ))}
           {hasScore && (
             <Badge
               appearance="filled"

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -9,7 +9,7 @@ import { ApiCard, type ApiCardApi } from '@/components/ApiCard';
 import { InfoTable } from '@/components/InfoTable';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { formatKindDisplay } from '@/utils/formatKind';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import { apiAdapter } from '@/experiences/ApiList/apiAdapter';
 import { useMcpTransportTags } from '@/hooks/useMcpTransportTags';
 import { ENABLE_LIST_EVAL_BADGES } from '@/constants/featureFlags';
@@ -169,7 +169,7 @@ export const ApiList: React.FC = () => {
             <InfoTable.Cell>
               {!!api.lifecycleStage && (
                 <Badge appearance="tint" color={getLifecycleBadgeColor(api.lifecycleStage)} shape="circular">
-                  {api.lifecycleStage}
+                  {formatLifecycleStage(api.lifecycleStage)}
                 </Badge>
               )}
             </InfoTable.Cell>

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -11,6 +11,7 @@ import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { formatKindDisplay } from '@/utils/formatKind';
 import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
 import { apiAdapter } from '@/experiences/ApiList/apiAdapter';
+import { useMcpTransportTags } from '@/hooks/useMcpTransportTags';
 import { ENABLE_LIST_EVAL_BADGES } from '@/constants/featureFlags';
 import { ContributeCard } from '@/experiences/ContributeCard';
 import { ApiMetadata } from '@/types/api';
@@ -46,6 +47,12 @@ export const ApiList: React.FC = () => {
     const adapted = apis.data?.map(apiAdapter) ?? [];
     return adapted;
   }, [apis.data]);
+
+  const mcpNames = useMemo(
+    () => adaptedApiList.filter((a) => a.type?.toLowerCase() === 'mcp').map((a) => a.name),
+    [adaptedApiList]
+  );
+  const mcpTransportTags = useMcpTransportTags(mcpNames);
 
   const getApiUrl = useCallback(
     (api: ApiCardApi) => {
@@ -121,7 +128,13 @@ export const ApiList: React.FC = () => {
             <ContributeCard url={config.contributions!.gitRepositoryUrl} />
           )}
           {adaptedApiList.map((api) => (
-            <ApiCard key={api.name} api={api} onClick={apiClickHandler(api)} showType />
+            <ApiCard
+              key={api.name}
+              api={api}
+              onClick={apiClickHandler(api)}
+              showType
+              transportTags={mcpTransportTags[api.name]}
+            />
           ))}
         </div>
         {renderLoadMore()}
@@ -170,6 +183,9 @@ export const ApiList: React.FC = () => {
                     {formatKindDisplay(api.type)}
                   </Badge>
                 )}
+                {mcpTransportTags[api.name]?.map((tag) => (
+                  <Badge key={tag} appearance="tint" color="brand" shape="circular">{tag}</Badge>
+                ))}
               </div>
             </InfoTable.Cell>
           </InfoTable.Row>

--- a/src/hooks/useMcpTransportTags.ts
+++ b/src/hooks/useMcpTransportTags.ts
@@ -1,0 +1,66 @@
+import { useQueries } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
+import { useApiService } from '@/hooks/useApiService';
+import { QueryKeys } from '@/constants/QueryKeys';
+
+export type McpTransport = 'Local' | 'Remote';
+
+/**
+ * For a list of MCP server names, fetches server + deployment data in parallel
+ * and returns a map of name → transport tags.
+ */
+export function useMcpTransportTags(mcpNames: string[]): Record<string, string[]> {
+  const ApiService = useApiService();
+  const isAuthenticated = useRecoilValue(isAuthenticatedAtom);
+
+  const serverQueries = useQueries({
+    queries: mcpNames.map((name) => ({
+      queryKey: [QueryKeys.Server, name],
+      queryFn: async () => {
+        const server = await ApiService.getServer(name);
+        return { name, server };
+      },
+      staleTime: Infinity,
+      enabled: isAuthenticated,
+    })),
+  });
+
+  const deploymentQueries = useQueries({
+    queries: mcpNames.map((name) => ({
+      queryKey: [QueryKeys.ApiDeployments, name],
+      queryFn: async () => {
+        const deployments = await ApiService.getDeployments(name);
+        return { name, deployments };
+      },
+      staleTime: Infinity,
+      enabled: isAuthenticated,
+    })),
+  });
+
+  const result: Record<string, string[]> = {};
+
+  for (let i = 0; i < mcpNames.length; i++) {
+    const name = mcpNames[i];
+    const serverData = serverQueries[i]?.data;
+    const deploymentData = deploymentQueries[i]?.data;
+
+    const hasLocal = !!serverData?.server?.packages?.length;
+    const hasRemote = !!serverData?.server?.remotes?.length ||
+      deploymentData?.deployments?.some(
+        (d) => d.server.runtimeUri.length > 0
+      );
+
+    if (hasRemote && hasLocal) {
+      result[name] = ['Remote + Local'];
+    } else if (hasRemote) {
+      result[name] = ['Remote'];
+    } else if (hasLocal) {
+      result[name] = ['Local'];
+    } else {
+      result[name] = [];
+    }
+  }
+
+  return result;
+}

--- a/src/pages/AgentChat/AgentChat.tsx
+++ b/src/pages/AgentChat/AgentChat.tsx
@@ -11,7 +11,7 @@ import {
 import { Link, useParams } from 'react-router-dom';
 import { LocationsService } from '@/services/LocationsService';
 import { useApi } from '@/hooks/useApi';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import styles from './AgentChat.module.scss';
 
@@ -207,7 +207,7 @@ export const AgentChat: React.FC = () => {
         {agentSummary && <p className={styles.summary}>{agentSummary}</p>}
         <div className={styles.metadata}>
           {agentKind && <Badge appearance="filled" color="brand" shape="circular">{agentKind.toUpperCase()}</Badge>}
-          {api.data?.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">{api.data.lifecycleStage}</Badge>}
+          {api.data?.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">{formatLifecycleStage(api.data.lifecycleStage)}</Badge>}
           {api.data?.lastUpdated && <span className={styles.lastUpdated}>Last updated {new Date(api.data.lastUpdated).toLocaleDateString()}</span>}
         </div>
       </section>

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -6,7 +6,7 @@ import { useApi } from '@/hooks/useApi';
 import { useAgentVersions } from '@/hooks/useAgentVersions';
 import { useAgentDefinition } from '@/hooks/useAgentDefinition';
 import { setDocumentTitle } from '@/utils/dom';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import { DetailPageLayout, BreadcrumbItem } from '@/components/DetailPageLayout/DetailPageLayout';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import CustomMetadata from '@/components/CustomMetadata';
@@ -86,7 +86,7 @@ export const AgentInfo: React.FC = () => {
           </Badge>
           {api.data?.lifecycleStage && (
             <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
-              {api.data.lifecycleStage}
+              {formatLifecycleStage(api.data.lifecycleStage)}
             </Badge>
           )}
         </>

--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -10,7 +10,7 @@ import ApiDefinitionSelect, { ApiDefinitionSelection } from '@/experiences/ApiDe
 import ApiAdditionalInfo from '@/experiences/ApiAdditionalInfo';
 import { HeaderActions } from '@/experiences/HeaderActions';
 import { formatKindDisplay } from '@/utils/formatKind';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import { buildSkillDeeplink } from '@/utils/skillDeeplink';
 import { useApiSpec } from '@/hooks/useApiSpec';
 import { useApiSpecUrl } from '@/hooks/useApiSpecUrl';
@@ -208,7 +208,7 @@ export const ApiDetailPage: React.FC = () => {
           )}
           {api.data?.lifecycleStage && (
             <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
-              {api.data.lifecycleStage}
+              {formatLifecycleStage(api.data.lifecycleStage)}
             </Badge>
           )}
           {customPropertyTags.length > 0 && (

--- a/src/pages/ApiSpec/ApiSpec.tsx
+++ b/src/pages/ApiSpec/ApiSpec.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, useLocation, Link } from 'react-router-dom';
 import { Badge, Spinner, Tab, TabList } from '@fluentui/react-components';
 import { DocumentRegular } from '@fluentui/react-icons';
 import { formatKindDisplay } from '@/utils/formatKind';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import { ApiDefinitionId, ResourceType } from '@/types/apiDefinition';
 import { useApi } from '@/hooks/useApi';
 import { setDocumentTitle } from '@/utils/dom';
@@ -74,7 +74,7 @@ export const ApiSpec: React.FC = () => {
         {(api.data.kind || api.data.lifecycleStage) && (
           <div className={styles.badges}>
             {api.data.kind && <Badge appearance="filled" color="brand" shape="circular">{formatKindDisplay(api.data.kind)}</Badge>}
-            {api.data.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">{api.data.lifecycleStage}</Badge>}
+            {api.data.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">{formatLifecycleStage(api.data.lifecycleStage)}</Badge>}
           </div>
         )}
         {api.data.summary && <p className={styles.summary}>{api.data.summary}</p>}

--- a/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
+++ b/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
@@ -61,6 +61,7 @@ export const McpServerDetailPage: React.FC = () => {
 
   const hasRemoteInstall = !!definitionSelection?.deployment?.server.runtimeUri.length;
   const hasLocalInstall = !!server.data?.packages;
+  const hasRemoteFromServer = !!server.data?.remotes?.length;
   const hasInstall = hasRemoteInstall || hasLocalInstall;
 
   const handleMcpInstall = useCallback((target?: 'remote' | 'local') => {
@@ -148,13 +149,13 @@ export const McpServerDetailPage: React.FC = () => {
           <Badge appearance="filled" color="brand" shape="circular">
             MCP
           </Badge>
-          {hasLocalInstall && hasRemoteInstall && (
-            <Badge appearance="tint" color="brand" shape="circular">Local + Remote</Badge>
+          {hasLocalInstall && (hasRemoteInstall || hasRemoteFromServer) && (
+            <Badge appearance="tint" color="brand" shape="circular">Remote + Local</Badge>
           )}
-          {hasLocalInstall && !hasRemoteInstall && (
+          {hasLocalInstall && !hasRemoteInstall && !hasRemoteFromServer && (
             <Badge appearance="tint" color="brand" shape="circular">Local</Badge>
           )}
-          {!hasLocalInstall && hasRemoteInstall && (
+          {!hasLocalInstall && (hasRemoteInstall || hasRemoteFromServer) && (
             <Badge appearance="tint" color="brand" shape="circular">Remote</Badge>
           )}
           {api.data?.lifecycleStage && (

--- a/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
+++ b/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
@@ -4,13 +4,14 @@ import { Badge, Button, Spinner, Tab, TabList } from '@fluentui/react-components
 import { DocumentRegular, TagRegular, WindowConsoleRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useServer } from '@/hooks/useServer';
+import { useMcpTransportTags } from '@/hooks/useMcpTransportTags';
 import { kindToResourceType, ApiDefinitionId } from '@/types/apiDefinition';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout, BreadcrumbItem } from '@/components/DetailPageLayout/DetailPageLayout';
 import ApiDefinitionSelect, { ApiDefinitionSelection } from '@/experiences/ApiDefinitionSelect';
 import ApiAdditionalInfo from '@/experiences/ApiAdditionalInfo';
 import { HeaderActions } from '@/experiences/HeaderActions';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import McpSpecPage from '@/pages/ApiSpec/McpSpecPage';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { InstallationBlock } from '@/components/InstallationBlock';
@@ -61,8 +62,10 @@ export const McpServerDetailPage: React.FC = () => {
 
   const hasRemoteInstall = !!definitionSelection?.deployment?.server.runtimeUri.length;
   const hasLocalInstall = !!server.data?.packages;
-  const hasRemoteFromServer = !!server.data?.remotes?.length;
   const hasInstall = hasRemoteInstall || hasLocalInstall;
+
+  const transportTags = useMcpTransportTags(apiName ? [apiName] : []);
+  const transportBadge = apiName ? transportTags[apiName]?.[0] : undefined;
 
   const handleMcpInstall = useCallback((target?: 'remote' | 'local') => {
     const useRemote = target ? target === 'remote' : hasRemoteInstall;
@@ -149,18 +152,12 @@ export const McpServerDetailPage: React.FC = () => {
           <Badge appearance="filled" color="brand" shape="circular">
             MCP
           </Badge>
-          {hasLocalInstall && (hasRemoteInstall || hasRemoteFromServer) && (
-            <Badge appearance="tint" color="brand" shape="circular">Remote + Local</Badge>
-          )}
-          {hasLocalInstall && !hasRemoteInstall && !hasRemoteFromServer && (
-            <Badge appearance="tint" color="brand" shape="circular">Local</Badge>
-          )}
-          {!hasLocalInstall && (hasRemoteInstall || hasRemoteFromServer) && (
-            <Badge appearance="tint" color="brand" shape="circular">Remote</Badge>
+          {transportBadge && (
+            <Badge appearance="tint" color="brand" shape="circular">{transportBadge}</Badge>
           )}
           {api.data?.lifecycleStage && (
             <Badge appearance="tint" color={getLifecycleBadgeColor(api.data.lifecycleStage)} shape="circular">
-              {api.data.lifecycleStage}
+              {formatLifecycleStage(api.data.lifecycleStage)}
             </Badge>
           )}
           {customPropertyTags.length > 0 && (

--- a/src/pages/ModelDetailPage/ModelDetailPage.tsx
+++ b/src/pages/ModelDetailPage/ModelDetailPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Link, Subtitle2 } from '@fluentui/react-components';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout, BreadcrumbItem } from '@/components/DetailPageLayout/DetailPageLayout';
 
@@ -30,7 +30,7 @@ export const ModelDetailPage: React.FC = () => {
           <Badge appearance="filled" color="brand" shape="circular">Model</Badge>
           {model.data?.lifecycleStage && (
             <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">
-              {model.data.lifecycleStage}
+              {formatLifecycleStage(model.data.lifecycleStage)}
             </Badge>
           )}
         </>

--- a/src/pages/ModelInfo/ModelInfo.tsx
+++ b/src/pages/ModelInfo/ModelInfo.tsx
@@ -16,7 +16,7 @@ import {
 import { Dismiss24Regular, OpenRegular } from '@fluentui/react-icons';
 import { useNavigate } from 'react-router-dom';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 
 import { LocationsService } from '@/services/LocationsService';
 import { EmptyStateMessage } from '@/components/EmptyStateMessage/EmptyStateMessage';
@@ -180,7 +180,7 @@ export const ModelInfo: React.FC<Props> = ({ name }) => {
 
         {model.data.lifecycleStage && (
           <div className={styles.badges}>
-            <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">{model.data.lifecycleStage}</Badge>
+            <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">{formatLifecycleStage(model.data.lifecycleStage)}</Badge>
           </div>
         )}
 

--- a/src/pages/ModelPlayground/ModelPlayground.tsx
+++ b/src/pages/ModelPlayground/ModelPlayground.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom';
 import { useApiDeployments } from '@/hooks/useApiDeployments';
 import { LocationsService } from '@/services/LocationsService';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
-import { getLifecycleBadgeColor } from '@/utils/badgeSystem';
+import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import styles from './ModelPlayground.module.scss';
 
@@ -213,7 +213,7 @@ export const ModelPlayground: React.FC = () => {
         {modelSummary && <p className={styles.summary}>{modelSummary}</p>}
         <div className={styles.metadata}>
           <Badge appearance="filled" color="brand" shape="circular">Model</Badge>
-          {model.data?.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">{model.data.lifecycleStage}</Badge>}
+          {model.data?.lifecycleStage && <Badge appearance="tint" color={getLifecycleBadgeColor(model.data.lifecycleStage)} shape="circular">{formatLifecycleStage(model.data.lifecycleStage)}</Badge>}
           {model.data?.lastUpdated && <span className={styles.lastUpdated}>Last updated {new Date(model.data.lastUpdated).toLocaleDateString()}</span>}
         </div>
       </section>

--- a/src/utils/badgeSystem.ts
+++ b/src/utils/badgeSystem.ts
@@ -29,3 +29,7 @@ export function getLifecycleBadgeColor(stage?: string): SemanticColor {
   if (!stage) return 'informative';
   return LIFECYCLE_COLORS[stage.toLowerCase()] ?? 'informative';
 }
+
+export function formatLifecycleStage(stage: string): string {
+  return stage.charAt(0).toUpperCase() + stage.slice(1).toLowerCase();
+}


### PR DESCRIPTION
## Summary

Adds Local/Remote transport tags to MCP server cards on the homepage and detail pages, and fixes lifecycle badge casing across all pages.

### Changes

**MCP Transport Tags**
- Homepage cards show `Local`, `Remote`, or `Remote + Local` tint badges for MCP servers
- Detail page uses the same shared hook (`useMcpTransportTags`) for consistency
- Tags derived from server `packages` (local) and `remotes`/`deployments` (remote)

**Lifecycle Badge Casing**
- Added `formatLifecycleStage()` utility for title casing (`production` → `Production`)
- Applied across all 9 pages that render lifecycle badges

<img width="1224" height="480" alt="Screenshot 2026-05-14 at 1 29 35 PM" src="https://github.com/user-attachments/assets/a80b76d4-8735-40b8-870d-8b0697542916" />


### New files
- `src/hooks/useMcpTransportTags.ts` — batch-fetches server + deployment data for MCP items

### Files changed (12 total)
- `ApiCard.tsx` — accepts optional `transportTags` prop
- `ApiList.tsx` — wires transport tags to cards and table view
- `McpServerDetailPage.tsx` — uses shared hook instead of local logic
- `badgeSystem.ts` — new `formatLifecycleStage` utility
- 8 detail/list pages — lifecycle badge title casing

---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*