### PR TITLE
Rename and reorder API detail page tabs for asset consistency

### DIFF
--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Button, Dropdown, Field, Link, Option, Tab, TabList } from '@fluentui/react-components';
-import { ArrowDownloadRegular, DocumentRegular, ListRegular, TagRegular } from '@fluentui/react-icons';
+import { ArrowDownloadRegular, CodeRegular, DocumentRegular, ListRegular, TagRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { kindToResourceType, ApiDefinitionId } from '@/types/apiDefinition';
 import { setDocumentTitle } from '@/utils/dom';
@@ -28,7 +28,7 @@ export const ApiDetailPage: React.FC = () => {
   const api = useApi(apiName);
   const config = useRecoilValue(configAtom);
   const [definitionSelection, setDefinitionSelection] = useState<ApiDefinitionSelection | undefined>();
-  const [selectedTab, setSelectedTab] = useState<string>('documentation');
+  const [selectedTab, setSelectedTab] = useState<string>('properties');
 
   setDocumentTitle(`API${api.data?.title ? ` - ${api.data.title}` : ''}`);
 
@@ -226,8 +226,8 @@ export const ApiDetailPage: React.FC = () => {
       lastUpdated={api.data?.lastUpdated}
       tabs={
         <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
-          <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
-          {hasAdditionalInfo && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
+          <Tab icon={<DocumentRegular />} value="properties">Documentation</Tab>
+          <Tab icon={<CodeRegular />} value="documentation">API specification</Tab>
         </TabList>
       }
       selector={
@@ -295,14 +295,14 @@ export const ApiDetailPage: React.FC = () => {
       emptyMessage={!api.isLoading && !api.isError && !api.data ? 'The specified API does not exist.' : undefined}
       sidebar={undefined}
     >
+      {api.data && selectedTab === 'properties' && (
+        <ApiAdditionalInfo api={api.data} />
+      )}
       {api.data && selectedTab === 'documentation' && (
         <>
           {renderInstallationBlock()}
           {renderDocumentation()}
         </>
-      )}
-      {api.data && selectedTab === 'properties' && (
-        <ApiAdditionalInfo api={api.data} />
       )}
     </DetailPageLayout>
   );


### PR DESCRIPTION
## Summary

Swaps the tab order on the API detail page and renames the tabs to match the pattern used by MCP servers, skills, and other asset types:

| Before | After |
|--------|-------|
| Tab 1: **Documentation** (spec viewer) | Tab 1: **Documentation** (description, contacts, external docs, custom props) |
| Tab 2: **Additional properties** (conditional) | Tab 2: **API specification** (spec viewer, `</>` icon) |

<img width="868" height="564" alt="Screenshot 2026-05-14 at 1 59 06 PM" src="https://github.com/user-attachments/assets/d74601db-9744-4092-9097-eabefa8b6df8" />
<img width="1180" height="671" alt="Screenshot 2026-05-14 at 1 59 09 PM" src="https://github.com/user-attachments/assets/2c8086d0-fbaf-42b5-bb0c-6868a224cebe" />




### Why

- **Consistency** — all other asset detail pages (MCP, skills, agents) lead with a "Documentation" tab
- **Content availability** — the Documentation tab always has content (description at minimum), while API specification may be empty if no spec is uploaded
- **Reduced cognitive load** — similar elements in similar positions across asset types

### Changes

- Reordered tabs: Documentation first, API specification second
- Renamed "Additional properties" → "Documentation"
- Renamed "Documentation" → "API specification"  
- Changed API specification icon to `CodeRegular` (`</>`)
- Documentation tab is now always visible (not conditional on `hasAdditionalInfo`)
- Default selected tab is now Documentation

Per feedback from @AZaslonov.

---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*