### PR TITLE
fix(agent): unbreak agent detail page + polish version dropdown

### DIFF
--- a/src/experiences/AgentDefinition/AgentDefinition.tsx
+++ b/src/experiences/AgentDefinition/AgentDefinition.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { MessageBar, MessageBarBody, Spinner } from '@fluentui/react-components';
+import { Spinner } from '@fluentui/react-components';
 import * as yaml from 'yaml';
 import { UseQueryResult } from '@tanstack/react-query';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
@@ -94,11 +94,7 @@ export const AgentDefinition: React.FC<Props> = ({ definition, hasVersion }) => 
   }
 
   if (definition.isError) {
-    return (
-      <MessageBar intent="error" className={styles.errorBar}>
-        <MessageBarBody>Failed to load the agent definition.</MessageBarBody>
-      </MessageBar>
-    );
+    return <EmptyStateMessage>No definition has been published for this version yet.</EmptyStateMessage>;
   }
 
   if (!parsed) {

--- a/src/experiences/VersionSelect/VersionSelect.module.scss
+++ b/src/experiences/VersionSelect/VersionSelect.module.scss
@@ -1,9 +1,15 @@
 .versionSelect {
+  max-width: 240px;
+
   .dropdown {
     background: var(--colorNeutralBackground1);
+    min-width: 0;
   }
 
   &.isInline {
+    width: fit-content;
+    max-width: none;
+
     .dropdown {
       min-width: 175px;
     }

--- a/src/mocks/agentEvaluationMocks.ts
+++ b/src/mocks/agentEvaluationMocks.ts
@@ -1,0 +1,70 @@
+/**
+ * DEV-ONLY mock evaluation results for previewing the Agent Assessment tab UI
+ * before the backend exposes real evaluation data.
+ *
+ * Mirrors the pattern in `skillEvaluationMocks.ts`. The fallback is gated behind
+ * `import.meta.env.DEV` in `useAgentEvaluationResult` so this data NEVER ships
+ * to production — it only fills in when running `npm start` locally and the
+ * backend returns nothing for an agent's evaluation result.
+ *
+ * To add a preview entry, key it by `agentName` (matches the route param in
+ * `/agents/:name`). Remove this file entirely once real evaluation data lands.
+ */
+import { AgentEvaluationResult } from '@/types/evaluation';
+
+const MOCK_AGENT_EVAL_RESULTS: Record<string, AgentEvaluationResult> = {
+  'support-triage-agent': {
+    agentName: 'support-triage-agent',
+    versionName: '1.0.0',
+    status: 'pass',
+    overallScore: 4.3,
+    maxScore: 5,
+    evaluationConfigurationName: 'default',
+    updatedOn: '2026-05-10T09:00:00Z',
+    structuralChecks: {
+      status: 'pass',
+      passed: 5,
+      total: 5,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'manifest-present', status: 'pass', message: 'Agent manifest found' },
+        { name: 'has-name', status: 'pass', message: 'Agent name declared' },
+        { name: 'has-description', status: 'pass', message: 'Description field present' },
+        { name: 'has-version', status: 'pass', message: 'Version declared' },
+        { name: 'has-entrypoint', status: 'pass', message: 'Entrypoint defined' },
+      ],
+    },
+    schemaValidation: {
+      status: 'pass',
+      passed: 4,
+      total: 4,
+      weightedScore: null,
+      maxWeightedScore: null,
+      assertions: [
+        { name: 'valid-schema', status: 'pass', message: 'Schema validates correctly' },
+        { name: 'has-capabilities', status: 'pass', message: 'Capabilities declared' },
+        { name: 'has-inputs', status: 'pass', message: 'Inputs defined' },
+        { name: 'has-outputs', status: 'pass', message: 'Outputs defined' },
+      ],
+    },
+    qualityAssessment: {
+      status: 'pass',
+      passed: 4,
+      total: 5,
+      weightedScore: 4.3,
+      maxWeightedScore: 5,
+      scores: [
+        { name: 'instruction-clarity', score: 4.5, maxScore: 5, passed: true, reasoning: 'Agent instructions are well-structured and unambiguous.' },
+        { name: 'capability-coverage', score: 4.2, maxScore: 5, passed: true, reasoning: 'Covers the main triage scenarios with appropriate fallbacks.' },
+        { name: 'safety-guidance', score: 4.6, maxScore: 5, passed: true, reasoning: 'Clear escalation rules and PII handling guidance.' },
+        { name: 'error-handling', score: 3.8, maxScore: 5, passed: false, reasoning: 'Handles common errors but missing retry guidance for transient failures.' },
+        { name: 'usage-examples', score: 4.4, maxScore: 5, passed: true, reasoning: 'Solid worked examples spanning multiple ticket types.' },
+      ],
+    },
+  },
+};
+
+export function getMockAgentEvalResult(agentName: string): AgentEvaluationResult | undefined {
+  return MOCK_AGENT_EVAL_RESULTS[agentName];
+}

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -162,20 +162,20 @@ export const ApiService: IApiService = {
 
   async getAgentEvaluationResult(agentName: string, versionName: string): Promise<AgentEvaluationResult | undefined> {
     return await HttpService.getOptional<AgentEvaluationResult>(
-      `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/evaluationResults/default`
+      `/apis/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/evaluationResults/default`
     );
   },
 
   async getAgentVersions(agentName: string): Promise<AgentVersion[]> {
     const response = await HttpService.get<{ value: AgentVersion[] }>(
-      `/agents/${encodeURIComponent(agentName)}/versions?$top=${DEFAULT_PAGE_SIZE}`
+      `/apis/${encodeURIComponent(agentName)}/versions?$top=${DEFAULT_PAGE_SIZE}`
     );
     return response?.value || [];
   },
 
   async getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined> {
     return await HttpService.getText(
-      `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
+      `/apis/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
     );
   },
 };


### PR DESCRIPTION
## Summary

Foundational fixes so the agent detail page actually loads, plus visual polish on the version dropdown.

After [#126](https://github.com/Azure/APICenter-Portal-Starter/pull/126) shipped agent evaluation, opening any agent's detail page locally either crashed Vite (missing mock file) or showed an empty page with a full-width version dropdown and a red error bar where the definition should be. This PR fixes the data path, restores the missing mock file, and polishes the empty/sizing states.

## Changes

### 1. Service: hit `/apis/{name}/...` for agent sub-resources
`getAgentVersions`, `getAgentDefinition`, and `getAgentEvaluationResult` were calling `/agents/{name}/...` but the data plane exposes agent sub-resources under `/apis/{name}/...` (same namespace as `getApi`, which already works). Without this, **no version, no definition, no assessment ever loads for kind=agent records** — verified against `apicenter-tools-demos`.

### 2. Restore missing `agentEvaluationMocks.ts`
[#126](https://github.com/Azure/APICenter-Portal-Starter/pull/126) added `useAgentEvaluationResult` with an import from `@/mocks/agentEvaluationMocks`, but the file itself was never committed (likely because `src/mocks/` is in `.gitignore`). This caused every fresh clone to crash with:

```
[plugin:vite:import-analysis] Failed to resolve import "@/mocks/agentEvaluationMocks"
```

The new file mirrors the existing `skillEvaluationMocks.ts` pattern exactly — DEV-only, gated behind `import.meta.env.DEV` in the hook so it never ships to production. Force-added past the ignore rule, same as the skill mocks.

### 3. `VersionSelect` width consistency
On agent pages, the version dropdown stretched to fill the entire header content column (because it's the only child of `.selectorInline`). API/MCP pages don't have this problem because they render multiple dropdowns side-by-side in a flex row.

Added `width: fit-content` + the existing `min-width: 175px` so the inline-mode dropdown sizes the same way across **agent, API, and MCP detail pages**.

### 4. `AgentDefinition` empty state
When a version has no published definition file, the backend returns 404 → `getText` returns `undefined` → react-query treats it as an error → the page rendered a red `MessageBar` ("Failed to load…"). But this isn't an error, it's an empty state — the version exists, the definition file just hasn't been published yet.

Swapped the `MessageBar` for the standard `EmptyStateMessage` illustration with copy: *"No definition has been published for this version yet."*

## Verification

Tested against `apicenter-tools-demos.data.centraluseuap.azure-apicenter.ms` with the `contoso-support-agent` record:

- ✅ Page loads (was crashing on missing mock import)
- ✅ Title, summary, badges render
- ✅ Version dropdown shows `v1`, sized consistently with API/MCP pages
- ✅ Definition tab shows empty-state illustration (no published def yet)
- ✅ Documentation tab renders the description

## Out of scope

Assessment tab rendering — Alex hasn't published an evaluation result for the test agent yet, so that path can't be visually verified end-to-end. Once an eval is published, the existing `EvaluationDetails` component will pick it up via the now-correct `/apis/{name}/versions/{v}/evaluationResults/default` path. If that needs polish, it's a follow-up PR.

---
*This PR was assisted by GitHub Copilot using Claude Opus 4.7*