### PR TITLE
revert: restore /agents/{name}/ URIs for agent sub-resources

### DIFF
--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -162,20 +162,20 @@ export const ApiService: IApiService = {
 
   async getAgentEvaluationResult(agentName: string, versionName: string): Promise<AgentEvaluationResult | undefined> {
     return await HttpService.getOptional<AgentEvaluationResult>(
-      `/apis/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/evaluationResults/default`
+      `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/evaluationResults/default`
     );
   },
 
   async getAgentVersions(agentName: string): Promise<AgentVersion[]> {
     const response = await HttpService.get<{ value: AgentVersion[] }>(
-      `/apis/${encodeURIComponent(agentName)}/versions?$top=${DEFAULT_PAGE_SIZE}`
+      `/agents/${encodeURIComponent(agentName)}/versions?$top=${DEFAULT_PAGE_SIZE}`
     );
     return response?.value || [];
   },
 
   async getAgentDefinition(agentName: string, versionName: string): Promise<string | undefined> {
     return await HttpService.getText(
-      `/apis/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
+      `/agents/${encodeURIComponent(agentName)}/versions/${encodeURIComponent(versionName)}/artifacts/definition/download`
     );
   },
 };


### PR DESCRIPTION
Reverts the URI change introduced in #127 in `src/services/ApiService.ts` that replaced `/agents/{name}/...` with `/apis/{name}/...` for agent sub-resources.

Agent sub-resources are served under the `/agents/` namespace, not `/apis/`. The PR #127 change was invalid and caused agent version, definition, and evaluation result requests to hit the wrong endpoint.

## Changes

Restore original URIs in:
- `getAgentEvaluationResult`
- `getAgentVersions`
- `getAgentDefinition`

Other changes from #127 (missing mock file, `VersionSelect` width fix, `AgentDefinition` empty state) are kept as-is.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>