### PR TITLE
feat: Add remote/local dropdown to MCP install button

### DIFF
--- a/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
+++ b/src/pages/McpServerDetailPage/McpServerDetailPage.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Button, Spinner, Tab, TabList } from '@fluentui/react-components';
+import {
+  Badge, Button, Spinner, Tab, TabList,
+  Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, MenuButton,
+} from '@fluentui/react-components';
 import { DocumentRegular, TagRegular, WindowConsoleRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useServer } from '@/hooks/useServer';
@@ -60,8 +63,8 @@ export const McpServerDetailPage: React.FC = () => {
     return tags;
   }, [api.data?.customProperties]);
 
-  const hasRemoteInstall = !!definitionSelection?.deployment?.server.runtimeUri.length;
-  const hasLocalInstall = !!server.data?.packages;
+  const hasRemoteInstall = !!definitionSelection?.deployment?.server.runtimeUri.length || !!server.data?.remotes?.length;
+  const hasLocalInstall = !!server.data?.packages?.length;
   const hasInstall = hasRemoteInstall || hasLocalInstall;
 
   const transportTags = useMcpTransportTags(apiName ? [apiName] : []);
@@ -72,7 +75,8 @@ export const McpServerDetailPage: React.FC = () => {
     const baseName = api.data?.title || apiName || '';
 
     if (useRemote && hasRemoteInstall) {
-      const runtimeUri = definitionSelection?.deployment?.server.runtimeUri[0];
+      const runtimeUri = definitionSelection?.deployment?.server.runtimeUri[0]
+        || server.data?.remotes?.[0]?.url;
       if (!runtimeUri) return;
       const matchingRemote = server.data?.remotes?.find((r) => r.url === runtimeUri);
       const transportType = matchingRemote?.transport_type || 'sse';
@@ -195,12 +199,50 @@ export const McpServerDetailPage: React.FC = () => {
       headerActions={
         hasInstall ? (
           <HeaderActions showExtensionHint>
-            <Button
-              icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
-              onClick={() => handleMcpInstall()}
-            >
-              Install in VS Code
-            </Button>
+            {hasRemoteInstall && hasLocalInstall ? (
+              <Menu positioning="below-end">
+                <MenuTrigger disableButtonEnhancement>
+                  <MenuButton
+                    icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
+                  >
+                    Install in VS Code
+                  </MenuButton>
+                </MenuTrigger>
+                <MenuPopover>
+                  <MenuList>
+                    <MenuItem
+                      icon={<img height={16} src={VsCodeLogo} alt="" />}
+                      onClick={() => handleMcpInstall('remote')}
+                    >
+                      <div style={{ display: 'flex', flexDirection: 'column' }}>
+                        <span>Install remote MCP server</span>
+                        <span style={{ fontSize: '12px', color: 'var(--colorNeutralForeground3)' }}>
+                          Hosted server, no local setup needed
+                        </span>
+                      </div>
+                    </MenuItem>
+                    <MenuItem
+                      icon={<img height={16} src={VsCodeLogo} alt="" />}
+                      onClick={() => handleMcpInstall('local')}
+                    >
+                      <div style={{ display: 'flex', flexDirection: 'column' }}>
+                        <span>Install local MCP server</span>
+                        <span style={{ fontSize: '12px', color: 'var(--colorNeutralForeground3)' }}>
+                          Runs on your machine via npx
+                        </span>
+                      </div>
+                    </MenuItem>
+                  </MenuList>
+                </MenuPopover>
+              </Menu>
+            ) : (
+              <Button
+                icon={<img height={18} src={VsCodeLogo} alt="VS Code" />}
+                onClick={() => handleMcpInstall()}
+              >
+                Install in VS Code
+              </Button>
+            )}
           </HeaderActions>
         ) : undefined
       }


### PR DESCRIPTION
## Summary

When an MCP server supports both remote and local installation, the **Install in VS Code** button now shows a dropdown (Fluent UI v9 `MenuButton`) letting users explicitly choose between:

- **Install remote MCP server** — hosted server, no local setup needed
- **Install local MCP server** — runs on your machine via npx

Each option includes a brief description to help users understand the difference.

When only one install type is available, the button remains a plain single-action button (no dropdown).

<img width="448" height="296" alt="Screenshot 2026-05-20 at 11 58 58 AM" src="https://github.com/user-attachments/assets/78f6606b-7323-4325-bc16-7463ee80731d" />




## Changes

- `McpServerDetailPage.tsx`: Replace plain `Button` with `Menu` + `MenuButton` when both remote and local install options exist
- Fix `hasRemoteInstall` detection to also check `server.data.remotes` (previously only checked async `definitionSelection.deployment`, causing the dropdown to not appear)
- Add descriptive text under each menu item using Fluent tokens for proper theming

---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*