### PR TITLE
fix: render API description in Documentation tab

### DIFF
--- a/src/components/DetailPageLayout/DetailPageLayout.module.scss
+++ b/src/components/DetailPageLayout/DetailPageLayout.module.scss
@@ -142,6 +142,14 @@
     min-width: 0;
     overflow-x: auto;
     line-height: 1.6;
+
+    > *:first-child {
+      margin-top: 0;
+
+      > *:first-child {
+        margin-top: 0;
+      }
+    }
   }
 
   .sidebar {

--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -22,6 +22,7 @@ import { configAtom } from '@/atoms/configAtom';
 import { InstallationBlock } from '@/components/InstallationBlock';
 import { Spinner } from '@fluentui/react-components';
 import VsCodeLogo from '@/assets/vsCodeLogo.svg';
+import { MarkdownRenderer } from '@/components/MarkdownRenderer/MarkdownRenderer';
 
 export const ApiDetailPage: React.FC = () => {
   const { apiName } = useParams<{ apiName: string }>();
@@ -296,7 +297,12 @@ export const ApiDetailPage: React.FC = () => {
       sidebar={undefined}
     >
       {api.data && selectedTab === 'properties' && (
-        <ApiAdditionalInfo api={api.data} />
+        <>
+          {api.data.description && api.data.description !== api.data.summary && (
+            <MarkdownRenderer markdown={api.data.description} />
+          )}
+          <ApiAdditionalInfo api={api.data} />
+        </>
       )}
       {api.data && selectedTab === 'documentation' && (
         <>


### PR DESCRIPTION
## Summary

API detail page was not rendering the `description` field from API metadata. The summary displayed under the title, but the longer-form description was missing from the Documentation tab.

## Changes

- **`ApiDetailPage.tsx`** — Added `MarkdownRenderer` to render `api.data.description` in the Documentation tab, above `ApiAdditionalInfo`. Skips rendering when description equals summary (matching the MCP server detail page pattern).
- **`DetailPageLayout.module.scss`** — Zeroed top margin on first child in `.main` so content sits flush with the 32px content padding.

## Screenshots

**Before:** Documentation tab shows no description (empty above Additional Info)
<img width="828" height="492" alt="image (84)" src="https://github.com/user-attachments/assets/bd2e45ed-1e2c-458d-8ce5-3cd30875b687" />

**After:** Description renders as markdown in the Documentation tab
<img width="736" height="412" alt="Screenshot 2026-06-02 at 2 37 54 PM" src="https://github.com/user-attachments/assets/15445802-4669-40b9-a45b-7c41cdc6e5de" />


---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*