### PR TITLE
fix: Hide Contains operator for enum filters in Add filter dropdown

### DIFF
--- a/src/experiences/AddFilterDropdown/AddFilterDropdown.tsx
+++ b/src/experiences/AddFilterDropdown/AddFilterDropdown.tsx
@@ -12,6 +12,7 @@ import {
 import { FilterRegular } from '@fluentui/react-icons';
 import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { FilterType, FilterOperator } from '@/types/apiFilters';
+import { ApiFilterParameters } from '@/config/apiFilters';
 import styles from './AddFilterDropdown.module.scss';
 
 const operatorLabels: Record<FilterOperator, string> = {
@@ -34,6 +35,9 @@ export const AddFilterDropdown: React.FC = () => {
   const availableValues = selectedFilterType
     ? searchFilters.metadata[selectedFilterType].options
     : [];
+
+  // Built-in filters (asset type, lifecycle) are known enums, so only exact-match (Equals) makes sense.
+  const isEnumFilter = selectedFilterType ? selectedFilterType in ApiFilterParameters : false;
 
   const handleApply = useCallback(() => {
     if (selectedFilterType && selectedValue) {
@@ -68,8 +72,12 @@ export const AddFilterDropdown: React.FC = () => {
             placeholder="Select options"
             value={selectedFilterType ? searchFilters.metadata[selectedFilterType].label : ''}
             onOptionSelect={(_, data) => {
-              setSelectedFilterType(data.optionValue as FilterType);
+              const type = data.optionValue as FilterType;
+              setSelectedFilterType(type);
               setSelectedValue('');
+              if (type in ApiFilterParameters) {
+                setSelectedOperator('eq');
+              }
             }}
           >
             {filterTypes.map((ft) => (
@@ -84,7 +92,7 @@ export const AddFilterDropdown: React.FC = () => {
             value={operatorLabels[selectedOperator]}
             onOptionSelect={(_, data) => setSelectedOperator(data.optionValue as FilterOperator)}
           >
-            <Option value="contains">Contains</Option>
+            {!isEnumFilter && <Option value="contains">Contains</Option>}
             <Option value="eq">Equals</Option>
           </Dropdown>
         </div>


### PR DESCRIPTION
## Summary
The "Add filter" dropdown previously offered both **Contains** and **Equals** operators for every property. For the built-in **Asset type** and **Lifecycle** filters the values are a fixed, known set of enums, so a substring `contains` match doesn't make sense and could produce confusing results.

This change restricts those enum-backed filters to the **Equals** operator only.

## Changes
- Hide the **Contains** operator option for built-in enum filters (`kind` / Asset type, `lifecycleStage` / Lifecycle) in the Add filter dropdown.
- Auto-select **Equals** when an enum filter property is chosen.
- Free-text/custom properties (e.g. Service Tree ID) continue to offer both **Contains** and **Equals**.

## Testing
- Lint of the changed file (pre-existing repo-wide prettier/sort-props issues are unrelated to this change).
- Manual UI check: selecting **Asset type** or **Lifecycle** shows only **Equals**; selecting a custom property still shows both operators.
