### PR TITLE
Enable Models as first-class asset type in APIC dev portal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ const App: React.FC = () => {
             element: <McpServerDetailPage />,
           },
           {
-            path: 'languageModels/:apiName',
+            path: 'models/:apiName/detail',
             element: <ModelDetailPage />,
           },
           {

--- a/src/components/ApiCard/ApiCard.tsx
+++ b/src/components/ApiCard/ApiCard.tsx
@@ -19,7 +19,7 @@ interface Props {
   transportTags?: string[];
 }
 
-const STANDALONE_KINDS = ['skill', 'a2a', 'mcp', 'plugin', 'agent', 'languagemodel'];
+const STANDALONE_KINDS = ['skill', 'a2a', 'mcp', 'plugin', 'agent', 'model', 'languagemodel'];
 
 function getCategoryLabel(type?: string): string {
   if (type && STANDALONE_KINDS.includes(type.toLowerCase())) {

--- a/src/components/ModelChatPlayground/ModelChatPlayground.module.scss
+++ b/src/components/ModelChatPlayground/ModelChatPlayground.module.scss
@@ -1,0 +1,188 @@
+.chatContainer {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 320px);
+  min-height: 300px;
+}
+
+.messages {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 1.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.inputArea {
+  flex-shrink: 0;
+  position: sticky;
+  bottom: 0;
+  background: var(--colorNeutralBackground1);
+  padding: 0.75rem 0 0;
+}
+
+.emptyState {
+  text-align: center;
+  color: var(--colorNeutralForeground3);
+  padding: 3rem 1rem;
+  font-size: 0.95rem;
+}
+
+.messageRow {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--colorBrandBackground);
+  color: var(--colorNeutralForegroundOnBrand);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 1rem;
+}
+
+.messageBubble {
+  max-width: 75%;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.userBubble {
+  margin-left: auto;
+  background: var(--colorBrandBackground);
+  color: var(--colorNeutralForegroundOnBrand);
+  border-bottom-right-radius: 4px;
+}
+
+.assistantBubble {
+  background: var(--colorNeutralBackground3);
+  border-bottom-left-radius: 4px;
+}
+
+.messageHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.senderName {
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.timestamp {
+  font-size: 0.7rem;
+  color: var(--colorNeutralForeground3);
+}
+
+.messageContent {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  word-break: break-word;
+
+  p {
+    margin: 0.25rem 0;
+  }
+}
+
+.thinkingIndicator {
+  padding: 0.75rem 1rem;
+}
+
+.inputWrapper {
+  position: relative;
+  background: var(--colorNeutralBackground1);
+  border: 1px solid var(--colorNeutralStroke1);
+  border-radius: 24px;
+  padding: 0;
+  overflow: hidden;
+
+  &:focus-within {
+    border-color: var(--colorNeutralStrokeAccessible);
+  }
+}
+
+.inputField {
+  display: block;
+  width: 100%;
+
+  &:global(.fui-Textarea) {
+    display: flex !important;
+    border: none !important;
+    background: transparent !important;
+    border-radius: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+
+    &::after,
+    &::before {
+      display: none !important;
+    }
+  }
+
+  :global(.fui-Textarea__textarea) {
+    padding: 14px 56px 14px 20px !important;
+    font-size: var(--fontSizeBase300);
+    line-height: var(--lineHeightBase300);
+    resize: none !important;
+    max-height: 240px;
+    overflow-y: auto !important;
+    background: transparent !important;
+    border: none !important;
+    outline: none !important;
+  }
+}
+
+.sendBtn {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  border-radius: var(--borderRadiusCircular);
+  color: var(--colorNeutralForeground4);
+  background: transparent;
+  transition: background-color var(--durationNormal) var(--curveEasyEase),
+              color var(--durationNormal) var(--curveEasyEase),
+              transform var(--durationFast) var(--curveDecelerateMid);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+
+  &:disabled {
+    color: var(--colorNeutralForeground4);
+    background: transparent;
+  }
+}
+
+.sendBtnActive {
+  background-color: var(--colorBrandBackground);
+  color: var(--colorNeutralForegroundOnBrand);
+
+  &:hover {
+    background-color: var(--colorBrandBackgroundHover);
+    color: var(--colorNeutralForegroundOnBrand);
+  }
+
+  &:active {
+    background-color: var(--colorBrandBackgroundPressed);
+    transform: scale(0.95);
+  }
+}
+
+.disclaimer {
+  margin: 0.5rem 0 1.5rem;
+  text-align: center;
+  font-size: 0.6875rem;
+  color: var(--colorNeutralForeground3);
+}

--- a/src/components/ModelChatPlayground/ModelChatPlayground.tsx
+++ b/src/components/ModelChatPlayground/ModelChatPlayground.tsx
@@ -1,0 +1,234 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { Button, Spinner, Textarea } from '@fluentui/react-components';
+import { ArrowRight24Regular, Bot24Regular } from '@fluentui/react-icons';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import styles from './ModelChatPlayground.module.scss';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+}
+
+interface ModelChatPlaygroundProps {
+  runtimeUrl: string;
+  modelTitle: string;
+  modelName?: string;
+}
+
+async function readSSEStream(
+  response: Response,
+  onDelta: (text: string) => void,
+  onComplete: () => void
+): Promise<void> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('No readable stream in response');
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const payload = line.slice(6).trim();
+        if (payload === '[DONE]') continue;
+
+        try {
+          const chunk = JSON.parse(payload);
+          const content = chunk?.choices?.[0]?.delta?.content;
+          if (content) onDelta(content);
+        } catch {
+          // Skip malformed JSON
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    onComplete();
+  }
+}
+
+function formatTimestamp(date: Date): string {
+  return date.toLocaleString(undefined, {
+    month: 'numeric',
+    day: 'numeric',
+    year: '2-digit',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+}
+
+const CHAT_PATH = '/chat/completions';
+
+export const ModelChatPlayground: React.FC<ModelChatPlaygroundProps> = ({ runtimeUrl, modelTitle, modelName }) => {
+  const chatUrl = runtimeUrl.replace(/\/$/, '') + CHAT_PATH;
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${Math.min(el.scrollHeight, 240)}px`;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  const sendMessage = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isLoading) return;
+
+    const userMessage: ChatMessage = { role: 'user', content: trimmed, timestamp: new Date() };
+    const updatedMessages = [...messages, userMessage];
+    setMessages([...updatedMessages, { role: 'assistant', content: '', timestamp: new Date() }]);
+    setInput('');
+    setIsLoading(true);
+
+    try {
+      const apiMessages = [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        ...updatedMessages.map(({ role, content }) => ({ role, content })),
+      ];
+
+      const response = await fetch(chatUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: modelName,
+          messages: apiMessages,
+          stream: true,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Model responded with status ${response.status}`);
+      }
+
+      await readSSEStream(
+        response,
+        (delta) => {
+          setMessages((prev) => {
+            const updated = [...prev];
+            const last = updated[updated.length - 1];
+            updated[updated.length - 1] = { ...last, content: last.content + delta };
+            return updated;
+          });
+        },
+        () => setIsLoading(false)
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
+      setMessages((prev) => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        if (last.role === 'assistant' && !last.content) {
+          updated[updated.length - 1] = { ...last, content: `Error: ${errorMessage}` };
+        } else {
+          updated.push({ role: 'assistant', content: `Error: ${errorMessage}`, timestamp: new Date() });
+        }
+        return updated;
+      });
+      setIsLoading(false);
+    }
+  }, [input, isLoading, chatUrl, messages, modelName]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        void sendMessage();
+      }
+    },
+    [sendMessage]
+  );
+
+  return (
+    <div className={styles.chatContainer}>
+      <div className={styles.messages}>
+        {messages.length === 0 && (
+          <div className={styles.emptyState}>
+            Start a conversation with the model. Ask anything to explore its capabilities.
+          </div>
+        )}
+        {messages.map((msg, i) =>
+          msg.role === 'assistant' && !msg.content ? null : (
+            <div key={i} className={styles.messageRow}>
+              {msg.role === 'assistant' && (
+                <div className={styles.avatar}>
+                  <Bot24Regular />
+                </div>
+              )}
+              <div className={`${styles.messageBubble} ${msg.role === 'user' ? styles.userBubble : styles.assistantBubble}`}>
+                {msg.role === 'assistant' && (
+                  <div className={styles.messageHeader}>
+                    <span className={styles.senderName}>{modelTitle}</span>
+                    <span className={styles.timestamp}>{formatTimestamp(msg.timestamp)}</span>
+                  </div>
+                )}
+                <div className={styles.messageContent}>
+                  {msg.role === 'assistant' ? <MarkdownRenderer markdown={msg.content} /> : msg.content}
+                </div>
+              </div>
+            </div>
+          )
+        )}
+        {isLoading && (
+          <div className={styles.messageRow}>
+            <div className={styles.avatar}>
+              <Bot24Regular />
+            </div>
+            <div className={styles.thinkingIndicator}>
+              <Spinner size="tiny" label="Model is thinking..." />
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className={styles.inputArea}>
+        <div className={styles.inputWrapper}>
+          <Textarea
+            className={styles.inputField}
+            textarea={{ ref: textareaRef }}
+            value={input}
+            onChange={(_, data) => { setInput(data.value); autoGrow(); }}
+            onKeyDown={handleKeyDown}
+            placeholder="Send a message..."
+            disabled={isLoading}
+            resize="none"
+          />
+          <Button
+            className={`${styles.sendBtn} ${input.trim() ? styles.sendBtnActive : ''}`}
+            appearance="transparent"
+            icon={<ArrowRight24Regular />}
+            onClick={() => void sendMessage()}
+            disabled={!input.trim() || isLoading}
+          />
+        </div>
+        <p className={styles.disclaimer}>
+          AI-generated content might be incorrect, so review carefully before use. Do not include personal or confidential information in the chat.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(ModelChatPlayground);

--- a/src/components/ModelChatPlayground/index.ts
+++ b/src/components/ModelChatPlayground/index.ts
@@ -1,0 +1,2 @@
+export { ModelChatPlayground } from './ModelChatPlayground';
+export { default } from './ModelChatPlayground';

--- a/src/config/apiFilters.ts
+++ b/src/config/apiFilters.ts
@@ -4,8 +4,11 @@ export const ApiFilterParameters: Record<FilterType, FilterMetadata> = {
   kind: {
     label: 'Asset type',
     options: [
+      { value: 'api', label: 'APIs' },
       { value: 'rest', label: 'REST' },
       { value: 'mcp', label: 'MCP' },
+      { value: 'agent', label: 'Agent' },
+      { value: 'model', label: 'Model' },
       { value: 'skill', label: 'Skill' },
       { value: 'a2a', label: 'A2A' },
       { value: 'plugin', label: 'Plugin' },
@@ -14,6 +17,7 @@ export const ApiFilterParameters: Record<FilterType, FilterMetadata> = {
       { value: 'soap', label: 'SOAP' },
       { value: 'webhook', label: 'Webhook' },
       { value: 'websocket', label: 'WebSocket' },
+      { value: 'odata', label: 'OData' },
     ],
   },
   lifecycleStage: {

--- a/src/experiences/ApiInfoOptions/ApiInfoOptions.tsx
+++ b/src/experiences/ApiInfoOptions/ApiInfoOptions.tsx
@@ -138,7 +138,7 @@ export const ApiInfoOptions: React.FC<Props> = ({ api, apiVersion, apiDefinition
               <Document20Regular /> <strong>API Definition</strong>
             </span>
 
-            {api.kind !== 'skill' && api.kind?.toLowerCase() !== 'languagemodel' && (
+            {api.kind !== 'skill' && api.kind?.toLowerCase() !== 'model' && api.kind?.toLowerCase() !== 'languagemodel' && (
               <span className={styles.linkGroup}>
                 {apiSpecUrl.data && api.kind !== 'mcp' && (
                   <Link href={apiSpecUrl.data} className={styles.link}>

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -61,7 +61,7 @@ export const ApiList: React.FC = () => {
       if (kind === 'skill') return LocationsService.getSkillInfoUrl(api.name);
       if (kind === 'plugin') return LocationsService.getPluginInfoUrl(api.name);
       if (kind === 'mcp') return LocationsService.getMcpServerUrl(api.name);
-      if (kind === 'languagemodel') return LocationsService.getModelPlaygroundUrl(api.name);
+      if (kind === 'model' || kind === 'languagemodel') return LocationsService.getModelDetailUrl(api.name);
       return LocationsService.getApiDetailUrl(api.name);
     },
     []
@@ -176,9 +176,9 @@ export const ApiList: React.FC = () => {
             <InfoTable.Cell>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <Badge appearance="filled" color="brand" shape="circular">
-                  {['skill', 'a2a', 'mcp', 'plugin', 'agent', 'languagemodel'].includes(api.type?.toLowerCase() ?? '') ? formatKindDisplay(api.type!) : 'API'}
+                  {['skill', 'a2a', 'mcp', 'plugin', 'agent', 'model', 'languagemodel'].includes(api.type?.toLowerCase() ?? '') ? formatKindDisplay(api.type!) : 'API'}
                 </Badge>
-                {!!api.type && !['skill', 'a2a', 'mcp', 'plugin', 'agent', 'languagemodel'].includes(api.type.toLowerCase()) && (
+                {!!api.type && !['skill', 'a2a', 'mcp', 'plugin', 'agent', 'model', 'languagemodel'].includes(api.type.toLowerCase()) && (
                   <Badge appearance="tint" color="brand" shape="circular">
                     {formatKindDisplay(api.type)}
                   </Badge>

--- a/src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx
+++ b/src/experiences/ApiSearchBox/ApiSearchAutoComplete/ApiSearchAutoComplete.tsx
@@ -23,7 +23,7 @@ function getNavigationTarget(api: ApiMetadata): { to: string; state?: HomeLocati
     return { to: LocationsService.getPluginInfoUrl(api.name) };
   }
 
-  if (kind === 'languagemodel') {
+  if (kind === 'model' || kind === 'languagemodel') {
     return { to: LocationsService.getModelDetailUrl(api.name) };
   }
 

--- a/src/experiences/CategoryPills/CategoryPills.tsx
+++ b/src/experiences/CategoryPills/CategoryPills.tsx
@@ -39,10 +39,10 @@ interface CategoryDef {
 
 const categories: CategoryDef[] = [
   { label: 'All assets' },
-  { label: 'APIs', kindValue: 'rest', icon: <PlugConnectedRegular /> },
+  { label: 'APIs', kindValue: 'api', icon: <PlugConnectedRegular /> },
   { label: 'Agents', kindValue: 'agent', icon: <AgentIcon /> },
   { label: 'MCP servers', kindValue: 'mcp', icon: <McpIcon /> },
-  // { label: 'Models', kindValue: 'languagemodel', icon: <BoxMultipleRegular /> },
+  { label: 'Models', kindValue: 'model', icon: <BoxMultipleRegular /> },
   { label: 'Plugins', kindValue: 'plugin', icon: <PluginIcon /> },
   { label: 'Skills', kindValue: 'skill', icon: <SkillIcon /> },
 ];

--- a/src/pages/AgentInfo/AgentInfo.tsx
+++ b/src/pages/AgentInfo/AgentInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Badge, Button, Tab, TabList } from '@fluentui/react-components';
-import { ArrowDownloadRegular, CodeRegular, DocumentRegular, PlugConnectedRegular } from '@fluentui/react-icons';
+import { ArrowDownloadRegular, CodeRegular, DocumentRegular, ListRegular, PlugConnectedRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
 import { useAIAssetVersions } from '@/hooks/useAIAssetVersions';
 import { useAIAssetDefinition } from '@/hooks/useAIAssetDefinition';
@@ -173,7 +173,7 @@ export const AgentInfo: React.FC = () => {
                 </Tab>
               );
             })()}
-          {hasCustomProps && <Tab value="properties">Additional properties</Tab>}
+          {hasCustomProps && <Tab icon={<ListRegular />} value="properties">Additional properties</Tab>}
         </TabList>
       }
       isLoading={api.isLoading}

--- a/src/pages/ApiDetailPage/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage/ApiDetailPage.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { Badge, Button, Dropdown, Field, Link, Option, Tab, TabList } from '@fluentui/react-components';
 import { ArrowDownloadRegular, CodeRegular, DocumentRegular, ListRegular, TagRegular } from '@fluentui/react-icons';
 import { useApi } from '@/hooks/useApi';
@@ -23,24 +23,32 @@ import { InstallationBlock } from '@/components/InstallationBlock';
 import { Spinner } from '@fluentui/react-components';
 import VsCodeLogo from '@/assets/vsCodeLogo.svg';
 import { MarkdownRenderer } from '@/components/MarkdownRenderer/MarkdownRenderer';
+import { LocationsService } from '@/services/LocationsService';
 
 export const ApiDetailPage: React.FC = () => {
   const { apiName } = useParams<{ apiName: string }>();
   const api = useApi(apiName);
   const config = useRecoilValue(configAtom);
+  const navigate = useNavigate();
   const [definitionSelection, setDefinitionSelection] = useState<ApiDefinitionSelection | undefined>();
   const [selectedTab, setSelectedTab] = useState<string>('properties');
 
   setDocumentTitle(`API${api.data?.title ? ` - ${api.data.title}` : ''}`);
 
   const kind = api.data?.kind;
-  const STANDALONE_KINDS = ['skill', 'a2a', 'plugin', 'agent', 'languagemodel'];
+
+  useEffect(() => {
+    if ((kind?.toLowerCase() === 'model' || kind?.toLowerCase() === 'languagemodel') && apiName) {
+      navigate(LocationsService.getModelDetailUrl(apiName), { replace: true });
+    }
+  }, [kind, apiName, navigate]);
+  const STANDALONE_KINDS = ['skill', 'a2a', 'plugin', 'agent', 'model', 'languagemodel'];
   const isStandaloneKind = kind ? STANDALONE_KINDS.includes(kind.toLowerCase()) : false;
   const categoryLabel = isStandaloneKind ? formatKindDisplay(kind!) : 'API';
 
   const CATEGORY_PLURALS: Record<string, string> = {
     rest: 'APIs', graphql: 'APIs', grpc: 'APIs', soap: 'APIs',
-    skill: 'Skills', plugin: 'Plugins', agent: 'Agents', a2a: 'Agents', languagemodel: 'Models',
+    skill: 'Skills', plugin: 'Plugins', agent: 'Agents', a2a: 'Agents', model: 'Models', languagemodel: 'Models',
   };
   const breadcrumbs = useMemo<BreadcrumbItem[]>(() => {
     const categoryPlural = CATEGORY_PLURALS[kind?.toLowerCase() ?? ''] ?? 'APIs';
@@ -122,7 +130,7 @@ export const ApiDetailPage: React.FC = () => {
   // Download definition — fetch available definitions and spec URL
   const apiDefinitions = useApiDefinitions(apiName, definitionSelection?.version?.name, kindToResourceType(api.data?.kind));
   const apiSpecUrl = useApiSpecUrl(definitionId ?? { apiName: '', versionName: '', definitionName: '' });
-  const DOWNLOAD_EXCLUDED_KINDS = ['mcp', 'skill', 'plugin', 'languagemodel'];
+  const DOWNLOAD_EXCLUDED_KINDS = ['mcp', 'skill', 'plugin', 'model', 'languagemodel'];
   const showDownloadDefinition = kind && !DOWNLOAD_EXCLUDED_KINDS.includes(kind.toLowerCase()) && !!definitionSelection?.definition;
 
   const [downloadDefinitionName, setDownloadDefinitionName] = useState<string | undefined>();

--- a/src/pages/ApiSpec/ApiSpec.tsx
+++ b/src/pages/ApiSpec/ApiSpec.tsx
@@ -17,7 +17,7 @@ import styles from './ApiSpec.module.scss';
 export const ApiSpec: React.FC = () => {
   const { apiName, versionName, definitionName } = useParams<Readonly<ApiDefinitionId>>() as ApiDefinitionId;
   const location = useLocation();
-  const resourceType: ResourceType = location.pathname.startsWith('/languageModels') ? 'languageModels' : 'apis';
+  const resourceType: ResourceType = location.pathname.startsWith('/models') ? 'models' : 'apis';
 
   const [deployment, setDeployment] = useState<ApiDeployment | null | undefined>();
   const [resolvedDefinitionName, setResolvedDefinitionName] = useState<string | undefined>(undefined);

--- a/src/pages/ModelDetailPage/ModelDetailPage.module.scss
+++ b/src/pages/ModelDetailPage/ModelDetailPage.module.scss
@@ -1,15 +1,8 @@
-.sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.section {
-  margin-bottom: 0;
-
-  h3 {
-    margin-bottom: 8px;
-  }
+.modelProperties {
+  margin-bottom: 24px;
+  padding: 16px 20px;
+  background: var(--colorNeutralBackground2);
+  border-radius: 8px;
 }
 
 .detailsGrid {
@@ -28,17 +21,8 @@
   }
 }
 
-.badgeSection {
-  margin-bottom: 24px;
-}
-
 .badges {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 8px;
-}
-
-.descriptionSection {
-  margin-top: 8px;
 }

--- a/src/pages/ModelDetailPage/ModelDetailPage.tsx
+++ b/src/pages/ModelDetailPage/ModelDetailPage.tsx
@@ -1,10 +1,15 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Badge, Link, Subtitle2 } from '@fluentui/react-components';
+import { Badge, Tab, TabList } from '@fluentui/react-components';
+import { ChatRegular, DocumentRegular } from '@fluentui/react-icons';
 import { useLanguageModel } from '@/hooks/useLanguageModel';
+import { useApiDeployments } from '@/hooks/useApiDeployments';
 import { getLifecycleBadgeColor, formatLifecycleStage } from '@/utils/badgeSystem';
 import { setDocumentTitle } from '@/utils/dom';
 import { DetailPageLayout, BreadcrumbItem } from '@/components/DetailPageLayout/DetailPageLayout';
+import ApiAdditionalInfo from '@/experiences/ApiAdditionalInfo';
+import { ModelChatPlayground } from '@/components/ModelChatPlayground';
+import { ApiMetadata } from '@/types/api';
 
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import styles from './ModelDetailPage.module.scss';
@@ -12,14 +17,32 @@ import styles from './ModelDetailPage.module.scss';
 export const ModelDetailPage: React.FC = () => {
   const { apiName } = useParams<{ apiName: string }>();
   const model = useLanguageModel(apiName);
+  const deployments = useApiDeployments(apiName, 'models');
+  const [selectedTab, setSelectedTab] = useState<string>('documentation');
 
   setDocumentTitle(`Model${model.data?.title ? ` - ${model.data.title}` : ''}`);
 
+  const hasDeployment = (deployments.data ?? []).length > 0;
+
+  const runtimeUrl = useMemo(() => {
+    const list = deployments.data ?? [];
+    const preferred = list.find((d) => d.recommended) ?? list[0];
+    return preferred?.server?.runtimeUri?.[0];
+  }, [deployments.data]);
+
   const breadcrumbs = useMemo<BreadcrumbItem[]>(() => [
     { label: 'Home', href: '/' },
-    { label: 'Models', href: '/?kind=languagemodel' },
+    { label: 'Models', href: '/?kind=model' },
     { label: model.data?.title || apiName || '...' },
   ], [model.data?.title, apiName]);
+
+  const hasModelDetails = !!(
+    model.data?.modelProvider || model.data?.modelName ||
+    model.data?.contextWindow?.inputTokens != null ||
+    model.data?.contextWindow?.outputTokens != null ||
+    model.data?.taskTypes?.length || model.data?.inputTypes?.length || model.data?.outputTypes?.length
+  );
+
   return (
     <DetailPageLayout
       title={model.data?.title}
@@ -36,137 +59,90 @@ export const ModelDetailPage: React.FC = () => {
         </>
       }
       lastUpdated={model.data?.lastUpdated}
-      headerActions={undefined}
+      tabs={
+        <TabList selectedValue={selectedTab} onTabSelect={(_, d) => setSelectedTab(d.value as string)}>
+          <Tab icon={<DocumentRegular />} value="documentation">Documentation</Tab>
+          {hasDeployment && <Tab icon={<ChatRegular />} value="playground">Test console</Tab>}
+        </TabList>
+      }
 
       isLoading={model.isLoading}
       error={model.isError ? 'Failed to load model details. Please check your connection and try again.' : undefined}
       onRetry={() => model.refetch()}
       emptyMessage={!model.isLoading && !model.isError && !model.data ? 'The specified model does not exist.' : undefined}
-      sidebar={
-        model.data ? (
-          <div className={styles.sidebar}>
-            {model.data.modelProvider && (
-              <div className={styles.section}>
-                <Subtitle2>Details</Subtitle2>
-                <dl className={styles.detailsGrid}>
-                  <dt>Provider</dt>
-                  <dd>{model.data.modelProvider}</dd>
-                  {model.data.modelName && (
-                    <>
-                      <dt>Model name</dt>
-                      <dd>{model.data.modelName}</dd>
-                    </>
-                  )}
-                  {model.data.contextWindow?.inputTokens != null && (
-                    <>
-                      <dt>Input tokens</dt>
-                      <dd>{model.data.contextWindow.inputTokens.toLocaleString()}</dd>
-                    </>
-                  )}
-                  {model.data.contextWindow?.outputTokens != null && (
-                    <>
-                      <dt>Output tokens</dt>
-                      <dd>{model.data.contextWindow.outputTokens.toLocaleString()}</dd>
-                    </>
-                  )}
-                </dl>
-              </div>
-            )}
-
-            {!!model.data.contacts?.length && (
-              <div className={styles.section}>
-                <Subtitle2>Contacts</Subtitle2>
-                {model.data.contacts.map((c, idx) => (
-                  <div key={idx}>
-                    {c.name && <span>{c.name}</span>}
-                    {c.email && (
-                      <>
-                        {' '}
-                        – <Link href={`mailto:${c.email}`}>{c.email}</Link>
-                      </>
-                    )}
-                    {c.url && (
-                      <>
-                        {' '}
-                        –{' '}
-                        <Link href={c.url} target="_blank">
-                          {c.url}
-                        </Link>
-                      </>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {!!model.data.externalDocumentation?.length && (
-              <div className={styles.section}>
-                <Subtitle2>External documentation</Subtitle2>
-                {model.data.externalDocumentation.map((doc, idx) => (
-                  <div key={idx}>
-                    {doc.url ? (
-                      <Link href={doc.url} target="_blank">
-                        {doc.title || doc.url}
-                      </Link>
-                    ) : (
-                      <span>{doc.title}</span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        ) : undefined
-      }
+      sidebar={undefined}
     >
-      {model.data && (
-        <div>
-          {!!model.data.taskTypes?.length && (
-            <div className={styles.badgeSection}>
-              <Subtitle2>Task types</Subtitle2>
-              <div className={styles.badges}>
-                {model.data.taskTypes.map((t) => (
-                  <Badge key={t} appearance="tint" color="informative" shape="circular">
-                    {t}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {!!model.data.inputTypes?.length && (
-            <div className={styles.badgeSection}>
-              <Subtitle2>Input types</Subtitle2>
-              <div className={styles.badges}>
-                {model.data.inputTypes.map((t) => (
-                  <Badge key={t} appearance="tint" color="informative" shape="circular">
-                    {t}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {!!model.data.outputTypes?.length && (
-            <div className={styles.badgeSection}>
-              <Subtitle2>Output types</Subtitle2>
-              <div className={styles.badges}>
-                {model.data.outputTypes.map((t) => (
-                  <Badge key={t} appearance="tint" color="informative" shape="circular">
-                    {t}
-                  </Badge>
-                ))}
-              </div>
+      {model.data && selectedTab === 'documentation' && (
+        <>
+          {hasModelDetails && (
+            <div className={styles.modelProperties}>
+              <dl className={styles.detailsGrid}>
+                {model.data.modelProvider && (
+                  <>
+                    <dt>Provider</dt>
+                    <dd>{model.data.modelProvider}</dd>
+                  </>
+                )}
+                {model.data.modelName && (
+                  <>
+                    <dt>Model name</dt>
+                    <dd>{model.data.modelName}</dd>
+                  </>
+                )}
+                {model.data.contextWindow?.inputTokens != null && (
+                  <>
+                    <dt>Input tokens</dt>
+                    <dd>{model.data.contextWindow.inputTokens.toLocaleString()}</dd>
+                  </>
+                )}
+                {model.data.contextWindow?.outputTokens != null && (
+                  <>
+                    <dt>Output tokens</dt>
+                    <dd>{model.data.contextWindow.outputTokens.toLocaleString()}</dd>
+                  </>
+                )}
+                {!!model.data.taskTypes?.length && (
+                  <>
+                    <dt>Task types</dt>
+                    <dd>
+                      <div className={styles.badges}>
+                        {model.data.taskTypes.map((t) => (
+                          <Badge key={t} appearance="tint" color="informative" shape="circular">{t}</Badge>
+                        ))}
+                      </div>
+                    </dd>
+                  </>
+                )}
+                {!!model.data.inputTypes?.length && (
+                  <>
+                    <dt>Input types</dt>
+                    <dd>{model.data.inputTypes.join(', ')}</dd>
+                  </>
+                )}
+                {!!model.data.outputTypes?.length && (
+                  <>
+                    <dt>Output types</dt>
+                    <dd>{model.data.outputTypes.join(', ')}</dd>
+                  </>
+                )}
+              </dl>
             </div>
           )}
 
           {(model.data.description || model.data.summary) && (
-            <div className={styles.descriptionSection}>
-              <Subtitle2>Description</Subtitle2>
-              <MarkdownRenderer markdown={(model.data.description || model.data.summary)!} />
-            </div>
+            <MarkdownRenderer markdown={(model.data.description || model.data.summary)!} />
           )}
-        </div>
+
+          <ApiAdditionalInfo api={model.data as ApiMetadata} />
+        </>
+      )}
+
+      {model.data && selectedTab === 'playground' && hasDeployment && runtimeUrl && (
+        <ModelChatPlayground
+          runtimeUrl={runtimeUrl}
+          modelTitle={model.data.title || apiName || 'Model'}
+          modelName={model.data.modelName}
+        />
       )}
     </DetailPageLayout>
   );

--- a/src/pages/ModelPlayground/ModelPlayground.tsx
+++ b/src/pages/ModelPlayground/ModelPlayground.tsx
@@ -90,7 +90,7 @@ const CHAT_PATH = '/chat/completions';
 export const ModelPlayground: React.FC = () => {
   const { name } = useParams<{ name: string }>();
   const model = useLanguageModel(name);
-  const deployments = useApiDeployments(name, 'languageModels');
+  const deployments = useApiDeployments(name, 'models');
 
   const runtimeUrl = (() => {
     const list = deployments.data ?? [];
@@ -203,7 +203,7 @@ export const ModelPlayground: React.FC = () => {
         <nav className={styles.breadcrumb}>
           <a href="/" className={styles.breadcrumbLink}>Home</a>
           <span className={styles.breadcrumbSep}>/</span>
-          <a href="/?kind=languagemodel" className={styles.breadcrumbLink}>Models</a>
+          <a href="/?kind=model" className={styles.breadcrumbLink}>Models</a>
           <span className={styles.breadcrumbSep}>/</span>
           <span className={styles.breadcrumbCurrent}>{modelTitle}</span>
         </nav>

--- a/src/pages/PluginInfo/PluginInfo.tsx
+++ b/src/pages/PluginInfo/PluginInfo.tsx
@@ -42,7 +42,7 @@ function getResourceNavigation(name: string, kind?: string): { to: string; state
   const k = kind?.toLowerCase();
   if (k === 'agent') return { to: LocationsService.getAgentInfoUrl(name) };
   if (k === 'skill') return { to: LocationsService.getSkillInfoUrl(name) };
-  if (k === 'languagemodel') {
+  if (k === 'model' || k === 'languagemodel') {
     return { to: LocationsService.getModelDetailUrl(name) };
   }
   return {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -39,10 +39,14 @@ export const ApiService: IApiService = {
     }
 
     if (filters.length) {
+      const STANDALONE_KINDS = ['agent', 'mcp', 'model', 'skill', 'plugin'];
       const filtersByType = groupBy(filters, 'type');
       const filtersString = Object.values(filtersByType)
         .map((filters) => {
           const filtersSet = filters.map((filter) => {
+            if (filter.type === 'kind' && filter.value === 'api') {
+              return STANDALONE_KINDS.map((k) => `kind ne '${k}'`).join(' and ');
+            }
             if (filter.operator === 'contains') {
               return `contains(${filter.type}, '${filter.value}')`;
             }

--- a/src/services/LocationsService.ts
+++ b/src/services/LocationsService.ts
@@ -44,7 +44,7 @@ export const LocationsService = {
   },
 
   getModelDetailUrl(name: string): string {
-    return `/languageModels/${name}`;
+    return `/models/${name}/detail`;
   },
 
   getAgentChatUrl(name: string): string {

--- a/src/types/apiDefinition.ts
+++ b/src/types/apiDefinition.ts
@@ -1,10 +1,11 @@
 /** The asset-type route segment used in UI URLs. */
-export type ResourceType = 'apis' | 'languageModels';
+export type ResourceType = 'apis' | 'models';
 
 /** Maps an API kind to the matching UI route segment. */
 export function kindToResourceType(kind?: string): ResourceType {
-  if (kind?.toLowerCase() === 'languagemodel') {
-    return 'languageModels';
+  const k = kind?.toLowerCase();
+  if (k === 'model' || k === 'languagemodel') {
+    return 'models';
   }
   return 'apis';
 }

--- a/src/types/homeDrawer.ts
+++ b/src/types/homeDrawer.ts
@@ -1,4 +1,4 @@
-export type HomeDrawerKind = 'api' | 'languageModel';
+export type HomeDrawerKind = 'api' | 'model';
 
 export interface HomeDrawerSelection {
   kind: HomeDrawerKind;

--- a/src/utils/formatKind.ts
+++ b/src/utils/formatKind.ts
@@ -1,6 +1,7 @@
 const UPPERCASE_KINDS = ['mcp', 'a2a', 'rest', 'api', 'soap', 'grpc'];
 
 const CUSTOM_LABELS: Record<string, string> = {
+  model: 'Model',
   languagemodel: 'Model',
 };
 


### PR DESCRIPTION
## Summary

Enables **Models** as a fully supported asset type in the APIC developer portal, bringing it to parity with APIs, Agents, MCP servers, Skills, and Plugins.

## Changes

### Models category pill & kind rename
- Uncomments the Models category pill filter on the home page
- Updates the canonical kind value from `languagemodel` to `model` across 16 references in 10+ files (retains `languagemodel` as legacy alias for backward compatibility)
- Updates routes from `/languageModels/` to `/models/`

### APIs pill fix
- Fixes the APIs category pill which was incorrectly showing 7 individual filter tags (REST, GraphQL, gRPC, etc.)
- Now uses a single exclude-based filter (`kind ne 'agent' AND kind ne 'mcp' AND ...`) so clicking 'APIs' shows one clean "Asset type = APIs" tag

### Model detail page overhaul
- **Removes sidebar layout** — aligns with every other detail page which uses `sidebar={undefined}`
- **Inline test console** — extracts chat playground into a reusable `ModelChatPlayground` component and embeds it directly in the Test console tab (no more redirect to a separate duplicate page)
- **Standard contacts/docs** — uses `ApiAdditionalInfo` component for contacts, external docs, and custom properties (same pattern as MCP server pages)
- **Model properties card** — shows provider, model name, context window, task/IO types in a styled card in the Documentation tab
- **Deployment-based test console** — shows Test console tab when a deployment exists (previously required `taskTypes` to include `chatCompletion`)

### Agent page fix
- Adds missing `ListRegular` icon to the "Additional properties" tab

## Screenshots


<img width="835" height="401" alt="Screenshot 2026-06-12 at 4 08 29 PM" src="https://github.com/user-attachments/assets/b0324628-107e-497a-ac3c-83d4bfaf5f95" />

<img width="1473" height="863" alt="Screenshot 2026-06-12 at 4 08 21 PM" src="https://github.com/user-attachments/assets/047e2e85-167b-4fe6-bef8-937c39072004" />

## Testing
- Verified against `apicenter-tools-demos` demo instance with GPT 5.4 Nano model
- TypeScript compiles clean (0 new errors)
- All existing asset types (APIs, Agents, MCP, Skills, Plugins) continue working as before


---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*