### PR TITLE
fix(mcp): send auth credentials on MCP test console tool runs

### DIFF
--- a/.wiki/services.md
+++ b/.wiki/services.md
@@ -165,6 +165,32 @@ const makeRequestWithCache = memoizee(makeRequest);
 **File**: `src/services/McpService.ts`
 **Purpose**: MCP (Model Context Protocol) server communication
 
+#### Instance lifetime
+
+Two factories are exported:
+
+| Factory | Ownership | Used by |
+|---------|-----------|---------|
+| `getMcpService(uri, credentials?)` | Module-level shared instance, reused across calls | `McpSpecPage` (connect + capability listing) |
+| `createMcpService(uri, credentials?)` | Standalone instance owned by the caller | `useMcpTestRunController` (test console drawer) |
+
+`getMcpService` only rebuilds the shared instance when the server URI changes or the caller
+explicitly passes *different* credentials. Omitting `authCredentials` means "reuse whatever is
+already connected" and must never downgrade an authenticated instance to an anonymous one.
+
+Consumers with their own connection lifetime (the test console tears the connection down when the
+drawer closes) must use `createMcpService`, so that `closeConnection()` does not affect the shared
+instance the spec page is still using.
+
+#### Credential propagation
+
+`McpService.fetchProxy()` injects header-based credentials (`in: 'header'`) on **every** request —
+subscription key, OAuth bearer token, and Entra ID / MSAL token alike. Credentials are resolved by
+`McpSpecPage` and published to the subtree through `McpAuthProvider`
+(`src/contexts/McpAuthContext.tsx`); `useMcpTestRunController` reads them via
+`useMcpAuthCredentials()` so tool/prompt/resource execution is authenticated the same way
+discovery is.
+
 #### TODO: Methods & Protocol
 - [ ] Document MCP server API
 - [ ] Clarify streaming vs request/response

--- a/src/contexts/McpAuthContext.tsx
+++ b/src/contexts/McpAuthContext.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext } from 'react';
+import { ApiAuthCredentials } from '@/types/apiAuth';
+
+const McpAuthContext = createContext<ApiAuthCredentials | undefined>(undefined);
+
+interface Props {
+  credentials?: ApiAuthCredentials;
+  children: React.ReactNode;
+}
+
+/**
+ * Publishes the credentials the MCP server was connected with, so that consumers rendered
+ * below the spec page (e.g. the test console) issue their requests with the same credentials.
+ */
+export const McpAuthProvider: React.FC<Props> = ({ credentials, children }) => (
+  <McpAuthContext.Provider value={credentials}>{children}</McpAuthContext.Provider>
+);
+
+export function useMcpAuthCredentials(): ApiAuthCredentials | undefined {
+  return useContext(McpAuthContext);
+}

--- a/src/hooks/useMcpTestRunController.ts
+++ b/src/hooks/useMcpTestRunController.ts
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { HttpReqParam } from 'api-docs-ui';
 import { OperationMetadata } from '@/types/apiSpec';
 import { ApiDeployment } from '@/types/apiDeployment';
-import { getMcpService, McpService } from '@/services/McpService';
+import { createMcpService, McpService } from '@/services/McpService';
 import { McpCapabilityTypes } from '@/types/mcp';
+import { useMcpAuthCredentials } from '@/contexts/McpAuthContext';
 
 interface ReturnType {
   result?: string;
@@ -23,23 +24,24 @@ export function useMcpTestRunController(
   const [error, setError] = useState<string>(undefined);
   const [isRunning, setIsRunning] = useState(false);
 
+  const authCredentials = useMcpAuthCredentials();
+  const runtimeUri = deployment?.server?.runtimeUri?.[0];
+
   useEffect(() => {
-    const runtimeUri = deployment?.server.runtimeUri[0];
     if (!runtimeUri || !shouldConnect) {
-      return;
+      return undefined;
     }
 
-    setMcpService((prev) => {
-      prev?.closeConnection();
-      return getMcpService(deployment?.server.runtimeUri[0]);
-    });
-  }, [deployment?.server.runtimeUri, shouldConnect]);
+    // The test console owns its connection: it is torn down when the drawer closes, so it must
+    // not share the instance the spec page keeps alive.
+    const service = createMcpService(runtimeUri, authCredentials);
+    setMcpService(service);
 
-  useEffect(() => {
-    if (!shouldConnect && mcpService) {
-      mcpService.closeConnection();
-    }
-  }, [mcpService, shouldConnect]);
+    return () => {
+      service?.closeConnection();
+      setMcpService(undefined);
+    };
+  }, [authCredentials, runtimeUri, shouldConnect]);
 
   useEffect(() => {
     setResult(undefined);

--- a/src/pages/ApiSpec/McpSpecPage/McpSpecPage.tsx
+++ b/src/pages/ApiSpec/McpSpecPage/McpSpecPage.tsx
@@ -16,6 +16,7 @@ import { McpAuthService } from '@/services/McpAuthService';
 import { McpDiscoveredAuth } from '@/types/mcp';
 import { McpMsalAuthService } from '@/services/McpMsalAuthService';
 import { configAtom } from '@/atoms/configAtom';
+import { McpAuthProvider } from '@/contexts/McpAuthContext';
 import styles from './McpSpecPage.module.scss';
 import McpMetadataBasedAuthForm from './McpMetadataBasedAuthForm';
 
@@ -254,11 +255,9 @@ export const McpSpecPage: React.FC<Props> = ({ definitionId, deployment }) => {
   }
 
   return (
-    <ApiSpecPageLayout
-      definitionId={definitionId}
-      deployment={deployment}
-      apiSpec={apiSpec}
-    />
+    <McpAuthProvider credentials={authCredentials}>
+      <ApiSpecPageLayout definitionId={definitionId} deployment={deployment} apiSpec={apiSpec} />
+    </McpAuthProvider>
   );
 };
 

--- a/src/services/McpService.ts
+++ b/src/services/McpService.ts
@@ -70,8 +70,14 @@ export class McpService {
       this.sse.removeEventListener('endpoint', this.handleEndpointReceived);
       this.sse.removeEventListener('error', this.handleErrorReceived);
       this.sse.removeEventListener('message', this.handleMessageReceived);
+      this.sse.close();
     }
-    currentInstance = undefined;
+
+    // Only drop the shared instance when this *is* the shared instance. Instances created
+    // through createMcpService() are owned by their caller and must not clear it.
+    if (currentInstance === this) {
+      currentInstance = undefined;
+    }
   }
 
   public async collectMcpSpec(): Promise<string> {
@@ -395,22 +401,54 @@ export class McpService {
   }
 }
 
-let currentInstance: McpService | undefined;
-export function getMcpService(uri?: string, authCredentials?: ApiAuthCredentials): McpService | undefined {
-  let serverUri = uri;
-  if (serverUri.endsWith('/sse')) {
-    serverUri = serverUri.split('/').slice(0, -1).join('/');
+function normalizeServerUri(uri?: string): string | undefined {
+  if (!uri) {
+    return undefined;
   }
 
+  if (uri.endsWith('/sse')) {
+    return uri.split('/').slice(0, -1).join('/');
+  }
+
+  return uri;
+}
+
+/**
+ * Creates a standalone McpService owned by the caller.
+ *
+ * Use this when a consumer needs its own connection lifetime (e.g. the test console drawer,
+ * which tears the connection down on close) so that closing it doesn't affect the shared
+ * instance returned by getMcpService().
+ */
+export function createMcpService(uri?: string, authCredentials?: ApiAuthCredentials): McpService | undefined {
+  const serverUri = normalizeServerUri(uri);
   if (!serverUri) {
     return undefined;
   }
 
-  if (currentInstance?.serverUri !== serverUri) {
+  return new McpService(serverUri, authCredentials);
+}
+
+let currentInstance: McpService | undefined;
+
+/**
+ * Returns the shared McpService for the given server URI.
+ *
+ * Omitting `authCredentials` means "reuse whatever is already connected" — it must never
+ * downgrade an authenticated instance to an anonymous one.
+ */
+export function getMcpService(uri?: string, authCredentials?: ApiAuthCredentials): McpService | undefined {
+  const serverUri = normalizeServerUri(uri);
+  if (!serverUri) {
+    return undefined;
+  }
+
+  const isDifferentServer = currentInstance?.serverUri !== serverUri;
+  const isExplicitCredentialsChange =
+    !!currentInstance && authCredentials !== undefined && currentInstance.authCredentials !== authCredentials;
+
+  if (isDifferentServer || isExplicitCredentialsChange) {
     currentInstance?.closeConnection();
-    currentInstance = new McpService(serverUri, authCredentials);
-  } else if (currentInstance && currentInstance.authCredentials !== authCredentials) {
-    currentInstance.closeConnection();
     currentInstance = new McpService(serverUri, authCredentials);
   }
 


### PR DESCRIPTION
## Why

Running a tool from the developer portal Test console fails with 401 when the MCP server uses header-based authorization. Tool discovery works, so the console lists the tools fine, and then `tools/call` goes out with no credential header and the gateway rejects it.

The cause is two call sites disagreeing about credentials on the same module-level singleton:

- `McpSpecPage` builds the client with `getMcpService(runtimeUri, authCredentials)`.
- `useMcpTestRunController` builds it with `getMcpService(runtimeUri)` - no credentials.
- `getMcpService` treated the omitted argument as "credentials are `undefined`", saw `undefined !== authCredentials`, and actively tore down the authenticated instance to replace it with an anonymous one for the same URI.

`authCredentials` lived in `McpSpecPage` state and was never available further down the tree, so the hook had nothing to pass even if it wanted to.

This affects every header-based credential, not just subscription keys: the `Authorization: Bearer ...` tokens from the OAuth dynamic-registration and Entra ID / MSAL flows hit the identical defect. Subscription-key servers just make it most visible, since the failure only shows up at execution time.

## Approach

**Get the credentials to the run path.** Added `McpAuthContext` so `McpSpecPage` publishes the resolved credentials to its subtree, and `useMcpTestRunController` reads them via `useMcpAuthCredentials()`. This avoids prop-drilling through `ApiSpecPageLayout` -> `DefaultOperationDetails` / `McpResourceOperationDetails` -> `McpTestConsole`, three layers that have no interest in auth. The effect that builds the client now also depends on `authCredentials`, so a credential acquired after the console mounts (the MSAL consent path resolves asynchronously) is picked up.

**Give the test console its own client.** The console already tore its connection down when the drawer closed. Once it shares credentials with the spec page it would also share the instance, and closing the drawer would kill the connection the spec page is still using. Rather than reference-count the singleton, the run path now uses a new `createMcpService()` that returns a caller-owned instance. That removes the cross-component lifetime coupling instead of managing it.

**Make the factory fail safe.** `getMcpService()` now only rebuilds when the URI changes or the caller passes explicitly different credentials. Omitting `authCredentials` means "reuse what is already connected" and can no longer silently downgrade an authenticated client. That implicit downgrade is what turned a missing argument into a 401 rather than an obvious error.

## Also fixed along the way

- `closeConnection()` cleared the module-level `currentInstance` unconditionally, so closing any instance wiped the shared one. It now only clears when it *is* the shared instance.
- `closeConnection()` removed the `EventSource` listeners but never called `close()`, leaking a connection on every teardown. Not reachable today (`mcpTransport` is `StreamableHttp`), but it becomes a real leak now that the console opens and closes its own client.
- The `if (!serverUri) return undefined` guard in `getMcpService` sat *after* `serverUri.endsWith('/sse')`, so `getMcpService(undefined)` threw a `TypeError` before ever reaching it. The guard was dead code; it now runs first.

## Notes for reviewers

- No regression tests. The repo has no test infrastructure at all (no runner, no `test` script, no test files - `.wiki/testing-strategy.md` lists Vitest as future work), and standing one up was deliberately kept out of this PR to keep it focused. Worth a follow-up: assert at the `McpService` level that the credential header survives connect -> run, for both API-key and Bearer credentials.
- Longer term the module-level `currentInstance` singleton is still the underlying design smell. `createMcpService` sidesteps it for the run path rather than removing it.

## Validation

- `tsc --noEmit`: only the two pre-existing errors in `ConnectPanel.tsx` and `PluginInfo.tsx`, confirmed identical against a stashed baseline.
- `eslint`: clean on all touched files.
- `vite build`: succeeds.