### PR TITLE
Return OAuth authorization code in the URL fragment instead of the query string

### DIFF
--- a/.wiki/services.md
+++ b/.wiki/services.md
@@ -175,13 +175,50 @@ const makeRequestWithCache = memoizee(makeRequest);
 ### 6. OAuthService
 
 **File**: `src/services/OAuthService.ts`
-**Purpose**: OAuth 2.0 flows for test console
+**Purpose**: OAuth 2.0 flows for the test console ("Test with Authorization")
+
+#### Supported Flows
+- `authorization_code` / `authorization_code (PKCE)` → `authenticateCodeWithPkce()`
+- `implicit` → `authenticateImplicit()` (delegates token parsing to `client-oauth2`)
+
+Any other grant type throws `Unsupported grant type: <flow>`.
+
+#### Popup + callback bridge contract
+
+The flows are driven from a popup window (`openAuthPopup`), not a full-page redirect:
+
+1. `openAuthPopup()` opens the authorization URL in a popup and listens for `message` events.
+2. The authorization server redirects the popup back to the portal origin (`window.location.origin`
+   is always the `redirect_uri`).
+3. The inline bootstrap script in **`index.html`** is the callback bridge. It parses the response,
+   `postMessage`s an `OAuthCallbackPayload` (`code` / `state` / `error` / `error_description` /
+   `uri`) to `window.opener` targeting the portal origin, and closes itself.
+4. `openAuthPopup()` accepts the message only when `event.origin` matches the portal origin and the
+   payload has the expected shape, then surfaces provider errors, checks `state`, and hands the
+   payload to the flow-specific listener.
+
+**`index.html` and `OAuthService.ts` are two halves of one contract** — change them together.
+
+#### `response_mode=fragment`
+
+Both flows request `response_mode=fragment`, so the authorization code / token comes back in the URL
+**fragment**. Fragments are never sent to the server, so no server-side URL or query-string length
+limit (IIS `maxQueryString`/`maxUrl`, CDN or gateway limits) can reject a callback carrying a long
+authorization code. `response_mode` is a per-request parameter, not part of the app registration, so
+no change to a customer's identity provider configuration is required.
+
+Providers that do not implement `response_mode` ignore it and answer in the query string; the bridge
+parses **both** the fragment and the query string, so those providers keep working.
+
+#### Resilience
+
+- The popup is polled for closure, so dismissing it resolves with `undefined` instead of hanging.
+- A 5-minute timeout rejects with an actionable error so the UI never stays on "Authenticating".
+- A blocked popup produces an explicit "allow pop-ups" error.
 
 #### TODO: Implementation Details
-- [ ] Authorization code flow
 - [ ] Client credentials flow
 - [ ] Token refresh
-- [ ] Integration with `client-oauth2` package
 
 ---
 

--- a/.wiki/services.md
+++ b/.wiki/services.md
@@ -202,10 +202,10 @@ The flows are driven from a popup window (`openAuthPopup`), not a full-page redi
 #### `response_mode=fragment`
 
 Both flows request `response_mode=fragment`, so the authorization code / token comes back in the URL
-**fragment**. Fragments are never sent to the server, so no server-side URL or query-string length
-limit (IIS `maxQueryString`/`maxUrl`, CDN or gateway limits) can reject a callback carrying a long
-authorization code. `response_mode` is a per-request parameter, not part of the app registration, so
-no change to a customer's identity provider configuration is required.
+**fragment**. Fragments are never sent to the server, so no server-side URL or query string length
+limit can reject a callback carrying a long authorization code. `response_mode` is a per-request
+parameter, not part of the app registration, so no change to a customer's identity provider
+configuration is required.
 
 Providers that do not implement `response_mode` ignore it and answer in the query string; the bridge
 parses **both** the fragment and the query string, so those providers keep working.

--- a/index.html
+++ b/index.html
@@ -7,16 +7,52 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Tool portal</title>
   <script type="text/javascript">
+    /*
+     * OAuth callback bridge.
+     *
+     * The authorization server redirects the auth popup back to the portal origin. This script
+     * forwards the result to the window that opened the popup and closes it.
+     *
+     * The response may arrive either in the URL fragment (`response_mode=fragment`, which is what
+     * the portal asks for - fragments are never sent to the server, so no server-side URL/query
+     * length limit can ever truncate or reject the callback) or in the query string (providers
+     * that ignore `response_mode`). Both are parsed, with the fragment taking precedence.
+     */
     (() => {
-      const args = new URLSearchParams(window.location.search);
-      const code = args.get('code');
-
-      if (!opener || !code) {
+      if (!window.opener) {
         return;
       }
 
-      opener.postMessage({ code: code });
-      self.close();
+      const hash = window.location.hash.replace(/^#/, '');
+      const search = window.location.search.replace(/^\?/, '');
+      const hashParams = new URLSearchParams(hash);
+      const queryParams = new URLSearchParams(search);
+
+      const read = (name) => hashParams.get(name) || queryParams.get(name) || undefined;
+      const hasImplicitToken = (params) => params.has('access_token') || params.has('id_token');
+
+      // Raw response used by the implicit flow, which needs the untouched parameter string.
+      let uri;
+      if (hasImplicitToken(hashParams)) {
+        uri = '#' + hash;
+      } else if (hasImplicitToken(queryParams)) {
+        uri = '?' + search;
+      }
+
+      const payload = {
+        code: read('code'),
+        state: read('state'),
+        error: read('error'),
+        error_description: read('error_description'),
+        uri: uri,
+      };
+
+      if (!payload.code && !payload.error && !payload.uri) {
+        return;
+      }
+
+      window.opener.postMessage(payload, window.location.origin);
+      window.close();
     })();
   </script>
 </head>

--- a/src/hooks/useApiAuthorization.ts
+++ b/src/hooks/useApiAuthorization.ts
@@ -58,6 +58,7 @@ export function useApiAuthorization({ definitionId, schemeName }: Props): Return
 
       try {
         setCredentials(undefined);
+        setAuthError(undefined);
         setIsAuthenticating(true);
         const token = await OAuthService.authenticate(schemeQuery.data.oauth2, OAuthGrantTypes[oauthFlow]);
         if (token !== undefined) {

--- a/src/pages/ApiSpec/McpSpecPage/McpMetadataBasedAuthForm/McpMetadataBasedAuthForm.tsx
+++ b/src/pages/ApiSpec/McpSpecPage/McpMetadataBasedAuthForm/McpMetadataBasedAuthForm.tsx
@@ -27,6 +27,7 @@ export const McpMetadataBasedAuthForm: React.FC<Props> = ({ credentials, onChang
   const handleAuthRequested = useCallback(
     async (flow: string) => {
       try {
+        setAuthError(undefined);
         setIsAuthenticating(true);
 
         // TODO: we should not really use proxy for oauth

--- a/src/services/OAuthService.ts
+++ b/src/services/OAuthService.ts
@@ -37,6 +37,9 @@ const AUTH_POPUP_TIMEOUT_MS = 5 * 60 * 1000;
 /** How often to check whether the user dismissed the authorization popup. */
 const POPUP_CLOSE_POLL_INTERVAL_MS = 500;
 
+/** Grace period after the popup disappears, to let an in-flight callback message land. */
+const POPUP_CLOSE_GRACE_MS = 1000;
+
 async function generateCodeChallenge(codeVerifier: string): Promise<string> {
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
 
@@ -107,20 +110,22 @@ function openAuthPopup(
         return;
       }
 
-      cleanUp();
-      closePopup();
-
       const payload = event.data as OAuthCallbackPayload;
 
-      if (payload.error) {
-        reject(new Error(payload.error_description || payload.error));
+      // Every in-flight authentication attempt listens on the same window, and a single callback
+      // is delivered to all of them. A response carrying a different `state` belongs to another
+      // attempt, so ignore it silently rather than failing this one. Providers that drop `state`
+      // altogether are still accepted - `event.origin` above is the guard that matters, and the
+      // PKCE code verifier binds the code to this session.
+      if (payload.state && payload.state !== expectedState) {
         return;
       }
 
-      // Authorization servers are required to echo `state` back, but not all of them do. Reject
-      // only when a value comes back and it does not match the one we sent.
-      if (payload.state && payload.state !== expectedState) {
-        reject(new Error('Authentication failed: the authorization server returned an unexpected state value.'));
+      cleanUp();
+      closePopup();
+
+      if (payload.error) {
+        reject(new Error(payload.error_description || payload.error));
         return;
       }
 
@@ -134,8 +139,17 @@ function openAuthPopup(
         return;
       }
 
-      cleanUp();
-      resolve(undefined);
+      // The bridge posts its message and only then closes itself, so a successful callback can
+      // race this poll. Give the pending message a chance to arrive before reporting a dismissal.
+      clearInterval(closePollTimer);
+      setTimeout(() => {
+        if (isSettled) {
+          return;
+        }
+
+        cleanUp();
+        resolve(undefined);
+      }, POPUP_CLOSE_GRACE_MS);
     }, POPUP_CLOSE_POLL_INTERVAL_MS);
 
     const timeoutTimer = setTimeout(() => {
@@ -175,8 +189,9 @@ export const OAuthService = {
 
     const query = {
       state,
-      // Implicit responses are always returned in the fragment; ask for it explicitly so that
-      // providers defaulting to `query` cannot leak tokens into a server-visible URL.
+      // Implicit responses are always returned in the fragment, but ask for it explicitly so a
+      // provider that would otherwise default to `query` cannot put an access token in a
+      // server-visible URL, where it would end up in request logs.
       response_mode: 'fragment',
     };
 
@@ -191,6 +206,10 @@ export const OAuthService = {
       authorizationUri: credentials.authorizationUrl,
       redirectUri: backendUrl,
       scopes: credentials.supportedScopes,
+      // `state` is passed through `query` rather than as a top-level option on purpose. As a
+      // top-level option `client-oauth2` would reject any response that does not echo `state`
+      // back, which would break providers that omit it. `openAuthPopup` is therefore the only
+      // place that checks `state`.
       query: query,
     });
 

--- a/src/services/OAuthService.ts
+++ b/src/services/OAuthService.ts
@@ -17,6 +17,26 @@ export interface OAuthTokenResponse {
   refresh_token: string;
 }
 
+/** Payload posted back by the OAuth callback bridge in `index.html`. */
+export interface OAuthCallbackPayload {
+  /** Authorization code, for the authorization code (PKCE) flow. */
+  code?: string;
+  /** Opaque value echoed back by the authorization server. */
+  state?: string;
+  /** OAuth error code, e.g. `access_denied`. */
+  error?: string;
+  /** Human readable description of the OAuth error. */
+  error_description?: string;
+  /** Raw fragment (or query string) carrying implicit flow tokens. */
+  uri?: string;
+}
+
+/** How long to wait for the authorization popup to report a result before giving up. */
+const AUTH_POPUP_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** How often to check whether the user dismissed the authorization popup. */
+const POPUP_CLOSE_POLL_INTERVAL_MS = 500;
+
 async function generateCodeChallenge(codeVerifier: string): Promise<string> {
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
 
@@ -37,47 +57,96 @@ function generateRandomString(length: number): string {
   return text;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ensurePopupIsClosed(popup: Window, receiveMessage: (event: MessageEvent<any>) => any): Promise<void> {
-  return new Promise((resolve) => {
-    const checkPopup = setInterval(() => {
-      if (!popup || popup.closed) {
-        clearInterval(checkPopup);
-        window.removeEventListener('message', receiveMessage, false);
-        resolve();
-      }
-    }, 500);
-  });
+/** Ensures a `message` event actually comes from our own OAuth callback bridge. */
+function isOAuthCallbackMessage(event: MessageEvent): boolean {
+  if (event.origin !== window.location.origin) {
+    return false;
+  }
+
+  const data = event.data as OAuthCallbackPayload | undefined;
+
+  return Boolean(data && typeof data === 'object' && (data.code || data.error || data.uri));
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function openAuthPopup(uri: string, listener: (event: MessageEvent<any>) => any): Promise<string | undefined> {
-  return new Promise<string>(async (resolve, reject) => {
-    try {
-      let isComplete = false;
-      const popup = window.open(uri, '_blank', 'width=400,height=500');
+/**
+ * Opens the authorization popup and resolves with the token produced by `listener` once the
+ * callback bridge reports back. Resolves with `undefined` if the user dismisses the popup.
+ */
+function openAuthPopup(
+  uri: string,
+  expectedState: string,
+  listener: (payload: OAuthCallbackPayload) => Promise<string | undefined>
+): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve, reject) => {
+    const popup = window.open(uri, '_blank', 'width=400,height=500');
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const receiveMessage = async (event: MessageEvent<any>): Promise<void> => {
-        isComplete = true;
-        try {
-          const result = await listener(event);
-          resolve(result);
-        } catch (error) {
-          reject(error);
-        } finally {
-          window.removeEventListener('message', listener, false);
-        }
-      };
-
-      window.addEventListener('message', receiveMessage, false);
-      await ensurePopupIsClosed(popup, receiveMessage);
-      if (!isComplete) {
-        resolve(undefined);
-      }
-    } catch (error) {
-      reject(error);
+    if (!popup) {
+      reject(new Error('Unable to open the sign-in window. Allow pop-ups for this site and try again.'));
+      return;
     }
+
+    let isSettled = false;
+
+    const cleanUp = (): void => {
+      isSettled = true;
+      window.removeEventListener('message', receiveMessage, false);
+      clearInterval(closePollTimer);
+      clearTimeout(timeoutTimer);
+    };
+
+    const closePopup = (): void => {
+      try {
+        popup.close();
+      } catch {
+        // The popup may already be gone - nothing to do.
+      }
+    };
+
+    const receiveMessage = (event: MessageEvent): void => {
+      if (isSettled || !isOAuthCallbackMessage(event)) {
+        return;
+      }
+
+      cleanUp();
+      closePopup();
+
+      const payload = event.data as OAuthCallbackPayload;
+
+      if (payload.error) {
+        reject(new Error(payload.error_description || payload.error));
+        return;
+      }
+
+      // Authorization servers are required to echo `state` back, but not all of them do. Reject
+      // only when a value comes back and it does not match the one we sent.
+      if (payload.state && payload.state !== expectedState) {
+        reject(new Error('Authentication failed: the authorization server returned an unexpected state value.'));
+        return;
+      }
+
+      listener(payload).then(resolve, reject);
+    };
+
+    window.addEventListener('message', receiveMessage, false);
+
+    const closePollTimer = setInterval(() => {
+      if (isSettled || !popup.closed) {
+        return;
+      }
+
+      cleanUp();
+      resolve(undefined);
+    }, POPUP_CLOSE_POLL_INTERVAL_MS);
+
+    const timeoutTimer = setTimeout(() => {
+      if (isSettled) {
+        return;
+      }
+
+      cleanUp();
+      closePopup();
+      reject(new Error('Authentication timed out before the authorization server responded. Please try again.'));
+    }, AUTH_POPUP_TIMEOUT_MS);
   });
 }
 
@@ -87,24 +156,28 @@ export const OAuthService = {
   authenticate(credentials: Oauth2Credentials, grantType: string, useProxy?: boolean): Promise<string | undefined> {
     const backendUrl = window.location.origin;
 
-    try {
-      switch (grantType) {
-        case OAuthGrantTypes.implicit:
-          return this.authenticateImplicit(backendUrl, credentials);
+    switch (grantType) {
+      case OAuthGrantTypes.implicit:
+        return this.authenticateImplicit(backendUrl, credentials);
 
-        case OAuthGrantTypes.authorizationCode:
-        case OAuthGrantTypes.authorizationCodeWithPkce:
-          return this.authenticateCodeWithPkce(backendUrl, credentials, useProxy);
-      }
-    } catch {
-      throw new Error('Authentication failed');
+      case OAuthGrantTypes.authorizationCode:
+      case OAuthGrantTypes.authorizationCodeWithPkce:
+        return this.authenticateCodeWithPkce(backendUrl, credentials, useProxy);
+
+      default:
+        throw new Error(`Unsupported grant type: ${grantType}`);
     }
   },
 
   /** Acquires access token using "implicit" grant flow. */
   authenticateImplicit(backendUrl: string, credentials: Oauth2Credentials): Promise<string | undefined> {
+    const state = uuid.v4();
+
     const query = {
-      state: uuid.v4(),
+      state,
+      // Implicit responses are always returned in the fragment; ask for it explicitly so that
+      // providers defaulting to `query` cannot leak tokens into a server-visible URL.
+      response_mode: 'fragment',
     };
 
     if (credentials.supportedScopes.includes('openid')) {
@@ -121,11 +194,11 @@ export const OAuthService = {
       query: query,
     });
 
-    const listener = async (event: MessageEvent): Promise<string> => {
-      const tokenHash = event.data['uri'];
+    const listener = async (payload: OAuthCallbackPayload): Promise<string | undefined> => {
+      const tokenHash = payload.uri;
 
       if (!tokenHash) {
-        return;
+        throw new Error('Authentication response did not contain a token');
       }
 
       const tokenInfo = await oauthClient.token.getToken(backendUrl + tokenHash);
@@ -137,7 +210,7 @@ export const OAuthService = {
       }
     };
 
-    return openAuthPopup(oauthClient.token.getUri(), listener);
+    return openAuthPopup(oauthClient.token.getUri(), state, listener);
   },
 
   async authenticateCodeWithPkce(
@@ -147,6 +220,7 @@ export const OAuthService = {
   ): Promise<string | undefined> {
     const codeVerifier = generateRandomString(64);
     const challengeMethod = crypto.subtle ? 'S256' : 'plain';
+    const state = uuid.v4();
 
     const codeChallenge = challengeMethod === 'S256' ? await generateCodeChallenge(codeVerifier) : codeVerifier;
 
@@ -154,15 +228,21 @@ export const OAuthService = {
 
     const args = new URLSearchParams({
       response_type: 'code',
+      // Return the code in the URL fragment instead of the query string. Fragments are never sent
+      // to the server, so long authorization codes cannot be rejected by server-side URL/query
+      // length limits (IIS `maxQueryString`, CDN/gateway limits). Providers that do not implement
+      // `response_mode` simply ignore it and the callback bridge falls back to the query string.
+      response_mode: 'fragment',
       client_id: credentials.clientId,
       code_challenge_method: challengeMethod,
       code_challenge: codeChallenge,
       redirect_uri: backendUrl,
       scope: credentials.supportedScopes.join(' '),
+      state,
     });
 
-    const listener = async (event: MessageEvent): Promise<string> => {
-      const authorizationCode = event.data['code'];
+    const listener = async (payload: OAuthCallbackPayload): Promise<string> => {
+      const authorizationCode = payload.code;
 
       if (!authorizationCode) {
         throw new Error('Authorization code is missing');
@@ -195,6 +275,6 @@ export const OAuthService = {
       return `${capitalize(tokenResponse.token_type)} ${tokenResponse.access_token}`;
     };
 
-    return openAuthPopup(`${credentials.authorizationUrl}?${args}`, listener);
+    return openAuthPopup(`${credentials.authorizationUrl}?${args}`, state, listener);
   },
 };

--- a/src/services/OAuthService.ts
+++ b/src/services/OAuthService.ts
@@ -229,9 +229,9 @@ export const OAuthService = {
     const args = new URLSearchParams({
       response_type: 'code',
       // Return the code in the URL fragment instead of the query string. Fragments are never sent
-      // to the server, so long authorization codes cannot be rejected by server-side URL/query
-      // length limits (IIS `maxQueryString`, CDN/gateway limits). Providers that do not implement
-      // `response_mode` simply ignore it and the callback bridge falls back to the query string.
+      // to the server, so long authorization codes cannot be rejected by server-side URL or query
+      // string length limits. Providers that do not implement `response_mode` simply ignore it and
+      // the callback bridge falls back to the query string.
       response_mode: 'fragment',
       client_id: credentials.clientId,
       code_challenge_method: challengeMethod,


### PR DESCRIPTION
## Problem

The OAuth **Test with Authorization** popup receives the authorization code in the **query string** (`https://{portal-origin}/?code=...`), so the callback is a full server round trip and is subject to server-side URL limits — IIS `maxQueryString`/`maxUrl`, Azure Front Door, and any future gateway. Microsoft Entra authorization codes larger than ~2 KB are rejected with **404.15** before the SPA ever sees them.

Raising the IIS limit (companion bug) unblocks customers, but it only moves the ceiling. It does not remove the dependency on how long Entra decides to make an authorization code, and every hosting layer in front of the portal imposes its own limit.

## Fix

Request **`response_mode=fragment`** on the authorize call. The code comes back in the URL **fragment**, which browsers never send to the server — so no server-side URL length limit can ever apply to the callback.

### Why this is safe

- **Entra** — [documented](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-auth-code-flow) as supported, "also supported if requesting *only* a code", which is exactly this request. It is what MSAL.js v2+ uses for SPAs.
- **No customer action required** — `response_mode` is a **per-request** parameter, not part of the app registration. Existing `spa`-type redirect URIs keep working unchanged.
- **Other providers** — `response_mode` is standard OAuth 2.0 / OIDC (Multiple Response Type Encoding Practices). Providers that don't implement it ignore the unknown parameter and still answer with `?code=...`. The callback bridge parses **both** the fragment and the query string, so those providers keep working.
- **MSAL Browser popup was considered and rejected** — it only covers Entra, but the portal must work with arbitrary customer-configured authorization servers (API Center authorization objects, MCP dynamic client registration). Keeping the provider-neutral bridge preserves that.

## Also fixed in the same path

These were found while working on the callback and are tightly coupled to it:

- **The implicit flow was structurally broken.** `authenticateImplicit()` expected the callback to post `event.data['uri']`, but `index.html` only ever posted `{ code }` — so any API whose `supportedFlows` included `implicit` failed **100% of the time**. The bridge now forwards the raw fragment.
- **Provider errors dead-ended on the portal home page.** `error` / `error_description` are now forwarded and surfaced in the UI.
- **Listener leak.** `openAuthPopup()` added `receiveMessage` but removed `listener`, leaking a `message` listener on every authentication attempt.
- **The button could hang on "Authenticating…" forever.** Added a 5-minute timeout and an explicit error when the popup is blocked.
- **`message` events are now filtered** by origin and payload shape, so unrelated `postMessage` traffic (browser extensions, devtools bridges) cannot resolve or reject an authentication attempt.
- **`state` is now sent** on the PKCE flow and validated when the provider echoes it back. Validation is conditional so providers that drop `state` are not broken.
- **`authenticate()` silently returned `undefined`** for unsupported grant types; it now throws.
- **`authError` persisted** after a successful retry.

## Back end

**No back-end change is required.** With fragment mode the server sees a plain `GET /` with no query string — the same request the portal already handles on every cold load — so the existing SPA rewrite serves `index.html` unchanged.

The raised `maxQueryString` / `maxUrl` limits from the companion bug should **stay in place** as defence in depth and for the query-string fallback path.

## Verification

Ran the **real** callback script and the **real** compiled `OAuthService` against stubbed browser globals:

**Callback bridge (8 cases)** — fragment code, query-string fallback, fragment-wins-over-query, provider error in both fragment and query, implicit `access_token` and `id_token`, no-opener normal page load, ordinary navigation with unrelated query params.

**OAuthService (10 cases)** — `response_mode=fragment` present on both flows, foreign-origin and noise messages ignored, happy-path token exchange, listener removed after completion, provider error surfaced, mismatched `state` rejected, dismissed popup resolves, timeout rejects and clears state, blocked popup errors, implicit flow returns a token, unsupported grant type throws.

`vite build` confirms `response_mode:"fragment"` in the shipped bundle and the bridge in `dist/index.html`. ESLint clean on all changed files. `tsc` introduces no new errors (`ConnectPanel.tsx:23` and `PluginInfo.tsx:111` already fail on `main`).

## Note for reviewers

`index.html` and `src/services/OAuthService.ts` are **two halves of one contract** — the inline bridge script produces the payload that `openAuthPopup` consumes. The coupling is invisible from either file alone, so it is now documented in `.wiki/services.md`.

## Still to verify in a deployed environment

The end-to-end acceptance criteria can't be checked from a local checkout:

- OAuth completes in the **managed** portal for a tenant whose code exceeds 2 KB, with `maxQueryString` temporarily at its **default**.
