### PR TITLE
feat: Support multi-select (array) custom metadata filters

### DIFF
--- a/.wiki/requirements/asset-list-controls.md
+++ b/.wiki/requirements/asset-list-controls.md
@@ -25,5 +25,11 @@
 
 ### Custom Metadata Properties
 - Custom properties from `/metadataSchemas` are included in the filter dropdown alongside built-in filters (API type, Lifecycle).
-- Only metadata schemas with **enum** values are shown as filter options.
+- Metadata schemas with a fixed value set are shown as filter options. Supported shapes:
+  - Top-level `enum` values.
+  - Top-level `oneOf` entries (`const` value, optional `description` label).
+  - `boolean` type (rendered as Yes/No).
+  - **Multi-select** (`type: "array"`) where the value set is defined on `items.enum` or `items.oneOf`.
+- Multi-select (array) properties are matched with an OData lambda operator, e.g. `customProperties/tags/any(t: t eq 'Bug')`.
 - Filter keys for custom properties use the format `customProperties/{name}`.
+

--- a/src/experiences/AddFilterDropdown/AddFilterDropdown.tsx
+++ b/src/experiences/AddFilterDropdown/AddFilterDropdown.tsx
@@ -26,6 +26,7 @@ export const AddFilterDropdown: React.FC = () => {
   const [selectedFilterType, setSelectedFilterType] = useState<FilterType | ''>('');
   const [selectedOperator, setSelectedOperator] = useState<FilterOperator>('contains');
   const [selectedValue, setSelectedValue] = useState('');
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
 
   const filterTypes = Object.entries(searchFilters.metadata).map(([key, meta]) => ({
     key: key as FilterType,
@@ -36,25 +37,45 @@ export const AddFilterDropdown: React.FC = () => {
     ? searchFilters.metadata[selectedFilterType].options
     : [];
 
-  // Built-in filters (asset type, lifecycle) are known enums, so only exact-match (Equals) makes sense.
-  const isEnumFilter = selectedFilterType ? selectedFilterType in ApiFilterParameters : false;
+  // Multi-value (array) properties allow selecting several values at once via checkboxes.
+  const isMultiValue = selectedFilterType
+    ? Boolean(searchFilters.metadata[selectedFilterType]?.isMultiValue)
+    : false;
 
-  const handleApply = useCallback(() => {
-    if (selectedFilterType && selectedValue) {
-      searchFilters.add({ type: selectedFilterType, value: selectedValue, operator: selectedOperator });
-      setSelectedFilterType('');
-      setSelectedOperator('contains');
-      setSelectedValue('');
-      setIsOpen(false);
-    }
-  }, [searchFilters, selectedFilterType, selectedOperator, selectedValue]);
+  // Filters with a fixed value set (built-in enums or custom enum/multi-select metadata)
+  // only support exact matching, so we hide the "Contains" operator for them.
+  const isEnumFilter = selectedFilterType
+    ? selectedFilterType in ApiFilterParameters || availableValues.length > 0
+    : false;
 
-  const handleCancel = useCallback(() => {
+  const resetSelection = useCallback(() => {
     setSelectedFilterType('');
     setSelectedOperator('contains');
     setSelectedValue('');
-    setIsOpen(false);
+    setSelectedValues([]);
   }, []);
+
+  const handleApply = useCallback(() => {
+    if (!selectedFilterType) return;
+
+    if (isMultiValue) {
+      if (!selectedValues.length) return;
+      selectedValues
+        .filter((value) => !searchFilters.isActive({ type: selectedFilterType, value, operator: 'eq' }))
+        .forEach((value) => searchFilters.add({ type: selectedFilterType, value, operator: 'eq' }));
+    } else {
+      if (!selectedValue) return;
+      searchFilters.add({ type: selectedFilterType, value: selectedValue, operator: selectedOperator });
+    }
+
+    resetSelection();
+    setIsOpen(false);
+  }, [searchFilters, selectedFilterType, selectedOperator, selectedValue, selectedValues, isMultiValue, resetSelection]);
+
+  const handleCancel = useCallback(() => {
+    resetSelection();
+    setIsOpen(false);
+  }, [resetSelection]);
 
   return (
     <Popover open={isOpen} onOpenChange={(_, data) => setIsOpen(data.open)} positioning="below-end">
@@ -75,7 +96,10 @@ export const AddFilterDropdown: React.FC = () => {
               const type = data.optionValue as FilterType;
               setSelectedFilterType(type);
               setSelectedValue('');
-              if (type in ApiFilterParameters) {
+              setSelectedValues([]);
+              const hasFixedOptions =
+                type in ApiFilterParameters || (searchFilters.metadata[type]?.options.length ?? 0) > 0;
+              if (hasFixedOptions) {
                 setSelectedOperator('eq');
               }
             }}
@@ -99,7 +123,21 @@ export const AddFilterDropdown: React.FC = () => {
 
         <div className={styles.field}>
           <Label>Value</Label>
-          {selectedFilterType && availableValues.length && selectedOperator === 'eq' ? (
+          {selectedFilterType && isMultiValue ? (
+            <Dropdown
+              multiselect
+              placeholder="Select values"
+              selectedOptions={selectedValues}
+              value={selectedValues
+                .map((v) => availableValues.find((o) => o.value === v)?.label ?? v)
+                .join(', ')}
+              onOptionSelect={(_, data) => setSelectedValues(data.selectedOptions)}
+            >
+              {availableValues.map((opt) => (
+                <Option key={opt.value} value={opt.value}>{opt.label}</Option>
+              ))}
+            </Dropdown>
+          ) : selectedFilterType && availableValues.length && selectedOperator === 'eq' ? (
             <Dropdown
               placeholder="Search"
               value={selectedValue ? availableValues.find((v) => v.value === selectedValue)?.label ?? '' : ''}
@@ -120,7 +158,11 @@ export const AddFilterDropdown: React.FC = () => {
         </div>
 
         <div className={styles.actions}>
-          <Button appearance="primary" onClick={handleApply} disabled={!selectedFilterType || !selectedValue}>
+          <Button
+            appearance="primary"
+            onClick={handleApply}
+            disabled={!selectedFilterType || (isMultiValue ? !selectedValues.length : !selectedValue)}
+          >
             Apply
           </Button>
           <Button appearance="secondary" onClick={handleCancel}>

--- a/src/experiences/ApiList/ApiList.tsx
+++ b/src/experiences/ApiList/ApiList.tsx
@@ -29,9 +29,20 @@ export const ApiList: React.FC = () => {
   const searchFilters = useSearchFilters();
   const searchQuery = useSearchQuery();
   const navigate = useNavigate();
+  // Enrich active filters with schema info (e.g. multi-value/array properties) so the
+  // service can build the correct OData query. This is derived per-render and kept out
+  // of the atom to avoid interfering with filter equality checks (isActive/remove).
+  const enrichedFilters = useMemo(
+    () =>
+      searchFilters.activeFilters.map((filter) => ({
+        ...filter,
+        isMultiValue: searchFilters.metadata[filter.type]?.isMultiValue,
+      })),
+    [searchFilters.activeFilters, searchFilters.metadata]
+  );
   const apis = useApis({
     search: searchQuery.search,
-    filters: searchFilters.activeFilters,
+    filters: enrichedFilters,
     isSemanticSearch: searchQuery.isSemanticSearch,
   });
 

--- a/src/hooks/useMetadataSchemas.ts
+++ b/src/hooks/useMetadataSchemas.ts
@@ -3,19 +3,31 @@ import { useQuery } from '@tanstack/react-query';
 import { isAuthenticatedAtom } from '@/atoms/isAuthenticatedAtom';
 import { useApiService } from '@/hooks/useApiService';
 import { QueryKeys } from '@/constants/QueryKeys';
-import { MetadataSchemaWithTitle, ParsedMetadataSchema } from '@/types/metadataSchema';
+import { MetadataSchemaWithTitle, ParsedMetadataSchema, SchemaOneOfEntry } from '@/types/metadataSchema';
 
-function extractOptions(parsed: ParsedMetadataSchema): Array<{ value: string; label: string }> | undefined {
-  if (parsed.enum?.length) {
-    return parsed.enum.map((val) => ({ value: val, label: val }));
+type FilterOption = { value: string; label: string };
+
+function optionsFromEnum(values?: string[]): FilterOption[] | undefined {
+  if (!values?.length) return undefined;
+  return values.map((val) => ({ value: val, label: val }));
+}
+
+function optionsFromOneOf(oneOf?: SchemaOneOfEntry[]): FilterOption[] | undefined {
+  if (!oneOf?.length) return undefined;
+  const options = oneOf
+    .filter((entry) => entry.const != null)
+    .map((entry) => ({ value: entry.const!, label: entry.description || entry.const! }));
+  return options.length ? options : undefined;
+}
+
+function extractOptions(parsed: ParsedMetadataSchema): FilterOption[] | undefined {
+  // Multi-select: `type: 'array'` with the value set defined on `items`.
+  if (parsed.type === 'array' && parsed.items) {
+    return optionsFromEnum(parsed.items.enum) ?? optionsFromOneOf(parsed.items.oneOf);
   }
 
-  if (parsed.oneOf?.length) {
-    const options = parsed.oneOf
-      .filter((entry) => entry.const != null)
-      .map((entry) => ({ value: entry.const!, label: entry.description || entry.const! }));
-    if (options.length) return options;
-  }
+  const direct = optionsFromEnum(parsed.enum) ?? optionsFromOneOf(parsed.oneOf);
+  if (direct) return direct;
 
   if (parsed.type === 'boolean') {
     return [
@@ -50,6 +62,7 @@ export function useMetadataSchemas() {
             title: parsed.title || schema.name,
             type: parsed.type,
             options,
+            isMultiValue: parsed.type === 'array',
           });
         } catch {
           // If parsing fails, use the name as the title

--- a/src/hooks/useSearchFilters.ts
+++ b/src/hooks/useSearchFilters.ts
@@ -53,6 +53,7 @@ export function useSearchFilters(): ReturnType {
         combined[filterKey] = {
           label: schema.title,
           options: schema.options || [],
+          isMultiValue: schema.isMultiValue,
         };
       }
     }

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -47,6 +47,14 @@ export const ApiService: IApiService = {
             if (filter.type === 'kind' && filter.value === 'api') {
               return STANDALONE_KINDS.map((k) => `kind ne '${k}'`).join(' and ');
             }
+            // Multi-value (array) properties require an OData lambda operator to match
+            // against any element of the collection.
+            if (filter.isMultiValue) {
+              if (filter.operator === 'contains') {
+                return `${filter.type}/any(t: contains(t, '${filter.value}'))`;
+              }
+              return `${filter.type}/any(t: t eq '${filter.value}')`;
+            }
             if (filter.operator === 'contains') {
               return `contains(${filter.type}, '${filter.value}')`;
             }

--- a/src/types/apiFilters.ts
+++ b/src/types/apiFilters.ts
@@ -5,10 +5,14 @@ export type FilterOperator = 'eq' | 'contains';
 export interface FilterMetadata {
   label: string;
   options: Array<{ value: string; label: string }>;
+  /** True when the property holds an array of values (multi-select). */
+  isMultiValue?: boolean;
 }
 
 export interface ActiveFilterData {
   type: FilterType;
   value: string;
   operator?: FilterOperator;
+  /** True when the property holds an array of values, requiring lambda (`any`) filtering. */
+  isMultiValue?: boolean;
 }

--- a/src/types/metadataSchema.ts
+++ b/src/types/metadataSchema.ts
@@ -9,13 +9,27 @@ export interface MetadataSchema {
 }
 
 /**
+ * Enumerated value definition used by `oneOf` in a JSON schema.
+ */
+export interface SchemaOneOfEntry {
+  const?: string;
+  description?: string;
+}
+
+/**
  * Parsed schema content from the JSON schema string.
  */
 export interface ParsedMetadataSchema {
   type?: string;
   title?: string;
   enum?: string[];
-  oneOf?: Array<{ const?: string; description?: string }>;
+  oneOf?: SchemaOneOfEntry[];
+  /** Present for `type: 'array'` (multi-select) properties. */
+  items?: {
+    type?: string;
+    enum?: string[];
+    oneOf?: SchemaOneOfEntry[];
+  };
   [key: string]: unknown;
 }
 
@@ -27,4 +41,6 @@ export interface MetadataSchemaWithTitle {
   title: string;
   type?: string;
   options?: Array<{ value: string; label: string }>;
+  /** True when the property holds an array of values (multi-select). */
+  isMultiValue?: boolean;
 }


### PR DESCRIPTION
## Summary
Adds support for multi-select (array) custom-metadata filters. Previously only scalar `enum`, `oneOf`, and `boolean` metadata schemas produced filter options; array-typed properties (e.g. a `Tags` property whose value set is defined under `items.oneOf`) were ignored and could not be filtered on.

## Changes
- Recognize `type: "array"` metadata schemas and extract their option set from `items.enum` / `items.oneOf`.
- Tag array schemas as `isMultiValue` and thread that flag through filter metadata to the query boundary (kept out of the Recoil atom so filter equality checks and URL serialization are unchanged).
- In the Add filter dropdown, array properties render a Fluent multi-select value dropdown (with checkboxes), force the `eq` operator, hide the "Contains" operator, and add one active filter per selected value (skipping already-active values) — consistent with the enum-filter behavior from #132.
- Build the correct OData lambda query for array properties, e.g. `customProperties/tags/any(t: t eq 'Bug')`, grouped OR within a property and AND across properties.
- Document the supported schema shapes and `any()` filtering behavior in the asset-list-controls requirement doc.

## Testing
- `npx tsc --noEmit` — no new type errors (the 2 pre-existing errors on `main` in `ConnectPanel.tsx` / `PluginInfo.tsx` are unrelated); edited files report no language-server errors.
- Verified the data plane translates the generated OData correctly: `customProperties/tags/any(t: t eq 'Bug')` → `ARRAY_CONTAINS(c.customProperties.tags, 'Bug')`, and the OR variant → `ARRAY_CONTAINS(...) OR ARRAY_CONTAINS(...)`. Confirmed a plain `eq` on an array property cannot match, so the `any` lambda is required.
- Manual UI check against the `tags` schema (`type: array`, `items.oneOf` of `Bug` / `Task` / `Product backlog item`): checkbox multi-select renders and filtering returns the expected APIs.
