### PR TITLE
Validate OAuth authorization/token endpoint URL schemes

### DIFF
--- a/src/components/ConnectPanel/ConnectPanel.tsx
+++ b/src/components/ConnectPanel/ConnectPanel.tsx
@@ -6,8 +6,6 @@ import styles from './ConnectPanel.module.scss';
 interface ConnectPanelProps {
   /** The raw endpoint URL */
   endpointUrl?: string;
-  /** Asset name for display in snippets */
-  assetName?: string;
   /** Handler for VS Code install deeplink */
   onVsCodeInstall?: () => void;
   /** Whether VS Code install is available */
@@ -20,7 +18,6 @@ const EXTENSION_URL = 'https://marketplace.visualstudio.com/items?itemName=apide
 
 export const ConnectPanel: React.FC<ConnectPanelProps> = ({
   endpointUrl,
-  assetName,
   onVsCodeInstall,
   hasVsCodeInstall,
 }) => {

--- a/src/services/McpAuthService.ts
+++ b/src/services/McpAuthService.ts
@@ -210,6 +210,17 @@ async function registerClient(metadata: McpServerAuthMetadata): Promise<Oauth2Cr
       return undefined;
     }
 
+    // The authorization and token endpoints come from the publisher-controlled discovery
+    // document. The authorization endpoint is later handed to window.open(), so a
+    // `javascript:` / `data:` scheme would execute in the portal's own origin (stored XSS,
+    // enabling token theft). Require safe HTTPS URLs and fail closed on anything else.
+    if (!validateMetadataUrl(metadata.authorization_endpoint) || !validateMetadataUrl(metadata.token_endpoint)) {
+      console.warn(
+        'Auth server metadata contains an unsafe authorization_endpoint or token_endpoint; rejecting OAuth credentials.'
+      );
+      return undefined;
+    }
+
     const registrationResponse = await mcpFetch(metadata.registration_endpoint, {
       method: 'POST',
       headers: {

--- a/src/services/OAuthService.ts
+++ b/src/services/OAuthService.ts
@@ -72,6 +72,23 @@ function isOAuthCallbackMessage(event: MessageEvent): boolean {
 }
 
 /**
+ * Only http(s) URLs may be handed to `window.open`. Authorization endpoints ultimately
+ * originate from a publisher-controlled OAuth discovery document, so a dangerous scheme such
+ * as `javascript:`, `data:`, `blob:`, or `vbscript:` would execute in the portal's own origin
+ * (stored XSS). This is a defense-in-depth guard in addition to endpoint validation performed
+ * during OAuth discovery.
+ */
+function validateUriScheme(uri: string): boolean {
+  try {
+    const { protocol } = new URL(uri);
+
+    return protocol === 'https:' || protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Opens the authorization popup and resolves with the token produced by `listener` once the
  * callback bridge reports back. Resolves with `undefined` if the user dismisses the popup.
  */
@@ -81,6 +98,11 @@ function openAuthPopup(
   listener: (payload: OAuthCallbackPayload) => Promise<string | undefined>
 ): Promise<string | undefined> {
   return new Promise<string | undefined>((resolve, reject) => {
+    if (!validateUriScheme(uri)) {
+      reject(new Error('The authorization endpoint uses an unsupported URL scheme and was blocked.'));
+      return;
+    }
+
     const popup = window.open(uri, '_blank', 'width=400,height=500');
 
     if (!popup) {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -10,5 +10,6 @@ export interface PluginDetails {
   title: string;
   description?: string;
   version?: string;
+  lastUpdated?: string;
   resources: Record<string, PluginResource>;
 }


### PR DESCRIPTION
## Summary
Hardens the MCP OAuth flow against a stored-XSS / token-theft vector by validating the URL scheme of authorization and token endpoints that originate from a publisher-controlled OAuth discovery document.

## Motivation
The `authorization_endpoint` is eventually passed to `window.open()`. Because it comes from an untrusted, publisher-controlled discovery document, a dangerous scheme such as `javascript:`, `data:`, `blob:`, or `vbscript:` would execute in the portal's own origin, enabling stored XSS and OAuth token theft.

## Changes
- **`McpAuthService.registerClient`**: Reject OAuth credentials when `authorization_endpoint` or `token_endpoint` fail `validateMetadataUrl` (fail closed during discovery).
- **`OAuthService.openAuthPopup`**: Add a defense-in-depth `validateUriScheme` guard that only allows `http:`/`https:` URLs to reach `window.open()`; otherwise the popup is blocked and the promise rejects.
- Fix pre-existing build errors surfaced during verification:
  - Remove unused `assetName` prop from `ConnectPanel`.
  - Add optional `lastUpdated` field to the `PluginDetails` type (used by `PluginInfo`).

## Testing
- `npm run build` passes with no TypeScript errors.