### PR TITLE
Stop the OAuth callback bridge from closing the MSAL sign-in popup

### DIFF
--- a/.wiki/services.md
+++ b/.wiki/services.md
@@ -225,6 +225,23 @@ The flows are driven from a popup window (`openAuthPopup`), not a full-page redi
 
 **`index.html` and `OAuthService.ts` are two halves of one contract** — change them together.
 
+#### Claiming only our own responses
+
+This page is the default redirect target of every authentication library on this origin, not just
+`OAuthService`. In particular the **MSAL sign-in popup** (`MsalAuthService.signIn()`) is configured
+with no `redirectUri`, so MSAL defaults it to the portal page, and MSAL's own response also carries
+`code` and `state` in the fragment. A bridge that claimed it would `window.close()` the MSAL popup,
+MSAL's `monitorPopupForHash` would then observe `popupWindow.closed` and reject the sign-in with
+`user_cancelled`.
+
+The bridge therefore claims a response only when its `state` was issued by this portal.
+`src/utils/oauthState.ts` records issued values in `localStorage` under `apic.oauth.pendingStates`
+(with a TTL, released when the attempt settles) and the bridge reads that key directly — it runs
+before the bundle loads, so **the key literal is duplicated in `index.html`; keep the two in sync**.
+
+Responses carrying no `state` at all cannot be attributed and are still claimed, so providers that
+drop `state` keep working; `event.origin` and the PKCE code verifier remain the guards there.
+
 #### `response_mode=fragment`
 
 Both flows request `response_mode=fragment`, so the authorization code / token comes back in the URL

--- a/index.html
+++ b/index.html
@@ -17,11 +17,36 @@
      * the portal asks for - fragments are never sent to the server, so no server-side URL/query
      * length limit can ever truncate or reject the callback) or in the query string (providers
      * that ignore `response_mode`). Both are parsed, with the fragment taking precedence.
+     *
+     * This page is also the default redirect target of other authentication libraries running on
+     * this origin - notably the MSAL sign-in popup, which likewise comes back with `code` and
+     * `state` in the fragment. Closing that popup would abort its flow, so the bridge only claims
+     * a response whose `state` this portal issued. `OAUTH_PENDING_STATES_KEY` below mirrors
+     * `src/utils/oauthState.ts`; keep the two in sync.
      */
     (() => {
       if (!window.opener) {
         return;
       }
+
+      const OAUTH_PENDING_STATES_KEY = 'apic.oauth.pendingStates';
+
+      const isPortalIssuedState = (state) => {
+        try {
+          const raw = window.localStorage.getItem(OAUTH_PENDING_STATES_KEY);
+
+          if (!raw) {
+            return false;
+          }
+
+          const expiresAt = JSON.parse(raw)[state];
+
+          return typeof expiresAt === 'number' && expiresAt > Date.now();
+        } catch (e) {
+          // Storage unavailable or corrupt - we cannot attribute the response, so do not claim it.
+          return false;
+        }
+      };
 
       const hash = window.location.hash.replace(/^#/, '');
       const search = window.location.search.replace(/^\?/, '');
@@ -48,6 +73,15 @@
       };
 
       if (!payload.code && !payload.error && !payload.uri) {
+        return;
+      }
+
+      /*
+       * Responses from providers that drop `state` altogether cannot be attributed, so they are
+       * still claimed - the opener re-checks `event.origin` and the PKCE code verifier binds the
+       * code to this session.
+       */
+      if (payload.state && !isPortalIssuedState(payload.state)) {
         return;
       }
 

--- a/src/services/OAuthService.ts
+++ b/src/services/OAuthService.ts
@@ -3,6 +3,7 @@ import * as uuid from 'uuid';
 import { capitalize } from 'lodash';
 import { Oauth2Credentials, OAuthGrantTypes } from '@/types/apiAuth';
 import { apimFetchProxy } from '@/utils/apimProxy';
+import { issueOAuthState, releaseOAuthState } from '@/utils/oauthState';
 
 export interface OAuthTokenResponse {
   /** Access token. */
@@ -99,6 +100,7 @@ function openAuthPopup(
 ): Promise<string | undefined> {
   return new Promise<string | undefined>((resolve, reject) => {
     if (!validateUriScheme(uri)) {
+      releaseOAuthState(expectedState);
       reject(new Error('The authorization endpoint uses an unsupported URL scheme and was blocked.'));
       return;
     }
@@ -106,6 +108,7 @@ function openAuthPopup(
     const popup = window.open(uri, '_blank', 'width=400,height=500');
 
     if (!popup) {
+      releaseOAuthState(expectedState);
       reject(new Error('Unable to open the sign-in window. Allow pop-ups for this site and try again.'));
       return;
     }
@@ -114,6 +117,7 @@ function openAuthPopup(
 
     const cleanUp = (): void => {
       isSettled = true;
+      releaseOAuthState(expectedState);
       window.removeEventListener('message', receiveMessage, false);
       clearInterval(closePollTimer);
       clearTimeout(timeoutTimer);
@@ -207,7 +211,7 @@ export const OAuthService = {
 
   /** Acquires access token using "implicit" grant flow. */
   authenticateImplicit(backendUrl: string, credentials: Oauth2Credentials): Promise<string | undefined> {
-    const state = uuid.v4();
+    const state = issueOAuthState();
 
     const query = {
       state,
@@ -264,7 +268,7 @@ export const OAuthService = {
 
     const codeVerifier = generateRandomString(64);
     const challengeMethod = crypto.subtle ? 'S256' : 'plain';
-    const state = uuid.v4();
+    const state = issueOAuthState();
 
     const codeChallenge = challengeMethod === 'S256' ? await generateCodeChallenge(codeVerifier) : codeVerifier;
 

--- a/src/utils/oauthState.test.ts
+++ b/src/utils/oauthState.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+// The bridge is inline in `index.html` so it runs before the bundle; pull in the real markup rather
+// than a copy, so this test cannot drift from what ships.
+import indexHtml from '../../index.html?raw';
+import { OAUTH_PENDING_STATES_KEY, issueOAuthState, releaseOAuthState, isPortalIssuedOAuthState } from './oauthState';
+
+/**
+ * Extracts the inline OAuth callback bridge from `index.html` - it is one half of the contract with
+ * `OAuthService` and is otherwise never exercised by tests.
+ */
+function loadBridge(): string {
+  const script = indexHtml.match(/<script type="text\/javascript">([\s\S]*?)<\/script>/);
+
+  if (!script) {
+    throw new Error('Could not find the inline OAuth callback bridge in index.html');
+  }
+
+  return script[1];
+}
+
+interface BridgeResult {
+  postMessage: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+function runBridge(hash: string, search = ''): BridgeResult {
+  const postMessage = vi.fn();
+  const close = vi.fn();
+
+  const fakeWindow = {
+    opener: { postMessage },
+    location: { hash, search, origin: 'https://portal.example.com' },
+    localStorage,
+    close,
+  };
+
+  new Function('window', loadBridge())(fakeWindow);
+
+  return { postMessage, close };
+}
+
+describe('oauthState', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('recognises a state it issued', () => {
+    const state = issueOAuthState();
+
+    expect(isPortalIssuedOAuthState(state)).toBe(true);
+  });
+
+  it('does not recognise a foreign state', () => {
+    expect(isPortalIssuedOAuthState('some-other-library-state')).toBe(false);
+  });
+
+  it('forgets a released state', () => {
+    const state = issueOAuthState();
+
+    releaseOAuthState(state);
+
+    expect(isPortalIssuedOAuthState(state)).toBe(false);
+  });
+
+  it('discards expired states instead of accumulating them', () => {
+    const state = issueOAuthState();
+
+    localStorage.setItem(OAUTH_PENDING_STATES_KEY, JSON.stringify({ [state]: Date.now() - 1 }));
+
+    expect(isPortalIssuedOAuthState(state)).toBe(false);
+
+    issueOAuthState();
+
+    expect(Object.keys(JSON.parse(localStorage.getItem(OAUTH_PENDING_STATES_KEY)!))).not.toContain(state);
+  });
+
+  it('survives a corrupt registry', () => {
+    localStorage.setItem(OAUTH_PENDING_STATES_KEY, 'not json');
+
+    expect(isPortalIssuedOAuthState('anything')).toBe(false);
+    expect(() => issueOAuthState()).not.toThrow();
+  });
+});
+
+describe('index.html OAuth callback bridge', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('claims a response for a state this portal issued', () => {
+    const state = issueOAuthState();
+
+    const { postMessage, close } = runBridge(`#code=abc&state=${state}`);
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0]).toMatchObject({ code: 'abc', state });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the MSAL sign-in popup instead of closing it', () => {
+    // MSAL redirects back to this same page with its own code and state in the fragment. Claiming
+    // it closed the popup, so MSAL saw `popupWindow.closed` and rejected the sign-in.
+    const { postMessage, close } = runBridge('#code=0.AXkAmsal-code&client_info=eyJ1aWQiOiJ4In0&state=msal-owned');
+
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('ignores an error response belonging to another library', () => {
+    const { close } = runBridge('#error=access_denied&state=msal-owned');
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('still claims a response from a provider that drops state', () => {
+    const { postMessage, close } = runBridge('', '?code=abc');
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('claims implicit tokens for an issued state and forwards the raw fragment', () => {
+    const state = issueOAuthState();
+    const hash = `#access_token=token123&token_type=Bearer&state=${state}`;
+
+    const { postMessage, close } = runBridge(hash);
+
+    expect(postMessage.mock.calls[0][0]).toMatchObject({ uri: hash });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when there is no opener', () => {
+    const close = vi.fn();
+    const fakeWindow = {
+      opener: null,
+      location: { hash: '#code=abc', search: '', origin: 'https://portal.example.com' },
+      localStorage,
+      close,
+    };
+
+    new Function('window', loadBridge())(fakeWindow);
+
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/oauthState.ts
+++ b/src/utils/oauthState.ts
@@ -1,0 +1,98 @@
+import * as uuid from 'uuid';
+
+/**
+ * `localStorage` key holding the OAuth `state` values this portal has issued, mapped to the
+ * timestamp at which each stops being claimable.
+ *
+ * The inline callback bridge in `index.html` reads this key directly. It runs before the bundle
+ * loads and therefore cannot import from here, so the literal is duplicated there - keep the two
+ * in sync.
+ */
+export const OAUTH_PENDING_STATES_KEY = 'apic.oauth.pendingStates';
+
+/**
+ * How long an issued state stays claimable. Comfortably longer than the popup timeout in
+ * `OAuthService`, so a slow but legitimate sign-in is never rejected.
+ */
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+type PendingStates = Record<string, number>;
+
+function readPendingStates(): PendingStates {
+  try {
+    const raw = localStorage.getItem(OAUTH_PENDING_STATES_KEY);
+
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const now = Date.now();
+
+    // Drop expired entries so an abandoned popup cannot leave the key growing forever.
+    return Object.entries(parsed as PendingStates).reduce<PendingStates>((pending, [state, expiresAt]) => {
+      if (typeof expiresAt === 'number' && expiresAt > now) {
+        pending[state] = expiresAt;
+      }
+
+      return pending;
+    }, {});
+  } catch {
+    // Storage may be unavailable or hold something we did not write. Treat it as empty.
+    return {};
+  }
+}
+
+function writePendingStates(pending: PendingStates): void {
+  try {
+    localStorage.setItem(OAUTH_PENDING_STATES_KEY, JSON.stringify(pending));
+  } catch {
+    // Losing the registry only means the bridge will not claim this response - never throw here.
+  }
+}
+
+/**
+ * Creates an OAuth `state` and records it as issued by this portal, so the callback bridge can
+ * tell our authorization responses apart from those of other libraries sharing this origin.
+ *
+ * @returns The newly issued `state` value, to be sent on the authorization request.
+ * @example
+ * const state = issueOAuthState();
+ */
+export function issueOAuthState(): string {
+  const state = uuid.v4();
+  const pending = readPendingStates();
+
+  pending[state] = Date.now() + STATE_TTL_MS;
+  writePendingStates(pending);
+
+  return state;
+}
+
+/**
+ * Forgets a previously issued `state` once its authentication attempt has settled.
+ *
+ * @param state - The value returned by {@link issueOAuthState}.
+ */
+export function releaseOAuthState(state: string): void {
+  const pending = readPendingStates();
+
+  delete pending[state];
+  writePendingStates(pending);
+}
+
+/**
+ * Reports whether a `state` echoed back by an authorization server was issued by this portal and
+ * has not expired.
+ *
+ * @param state - The `state` value read from the authorization response.
+ * @returns `true` when the response belongs to an authentication attempt this portal started.
+ */
+export function isPortalIssuedOAuthState(state: string): boolean {
+  return typeof readPendingStates()[state] === 'number';
+}


### PR DESCRIPTION
## Problem

Microsoft Entra ID sign-in fails on current `main`. After the popup login the portal shows **"Oops, something went wrong"**, and the console reports:

```
Cross-Origin-Opener-Policy policy would block the window.closed call
  at monitorPopupForHash
  at acquireTokenPopupAsync
  at loginPopup
```

The COOP warning is a **symptom, not the cause**.

## Root cause

`MsalAuthService` configures no `redirectUri`, so MSAL defaults it to the portal page — and `msal-browser` 3.13.0 defaults `OIDCOptions.serverResponseType` to `FRAGMENT`. Entra therefore returns the MSAL sign-in response as `#code=…&state=…` **on the portal's own origin, inside the MSAL popup**, which is exactly where the inline OAuth callback bridge in `index.html` runs.

Since 47ab821 (#139) that bridge parses the fragment. It found MSAL's `code`, posted it to the opener and called `window.close()` — closing MSAL's own popup. MSAL's `monitorPopupForHash` then saw `popupWindow.closed` and rejected with `user_cancelled`. The COOP warning is emitted on that very `popupWindow.closed` read. The rejection reaches `AuthBtn`'s uncaught async `onClick`, hits the global `unhandledrejection` handler in `ErrorBoundary`, and renders the crash screen.

```
Entra → #code=…&state=… (portal origin, in MSAL popup)
      → index.html bridge claims it → window.close()
      → MSAL monitorPopupForHash sees popupWindow.closed  ← COOP warning here
      → reject(user_cancelled) → unhandledrejection → ErrorBoundary
```

Before #139 the bridge read `code` only from the **query string**. MSAL answers in the fragment, so the bridge found nothing and returned, and the popup survived — which is why rolling back that commit restores sign-in.

## Fix

Reverting fragment mode was rejected: it exists because Entra authorization codes larger than ~2 KB were rejected before reaching the SPA, and #139 also carries implicit-flow, error-surfacing, listener-leak and timeout fixes.

Instead the bridge now **claims only responses this portal started**. `OAuthService` registers every `state` it issues in `localStorage` (TTL, released once the attempt settles), and the bridge claims a response only when its `state` is one of them. MSAL's state is not, so its popup is left alone.

Responses carrying **no** `state` cannot be attributed and are still claimed, so providers that drop `state` keep working — `event.origin` and the PKCE code verifier remain the guards there.

No Entra app-registration change is required.

## Changes

| File | Change |
|---|---|
| `src/utils/oauthState.ts` *(new)* | Issue / release / validate states. TTL, prunes expired, never throws on storage failure. |
| `index.html` | Guard before `postMessage` + `close`. |
| `src/services/OAuthService.ts` | `issueOAuthState()` in both flows; `releaseOAuthState()` on settle, blocked popup, rejected URI scheme. |
| `src/utils/oauthState.test.ts` *(new)* | 11 tests. |
| `.wiki/services.md` | Documents the contract and the duplicated key literal. |

The bridge runs before the bundle loads and cannot import the key, so the literal is duplicated in `index.html`; both sides carry a keep-in-sync note.

## Validation

- **32/32 tests pass** (was 21).
- Tests execute the **real** script extracted from `index.html` via `?raw`, not a copy, so they cannot drift from what ships.
- **Guard proven effective:** stashing the `index.html` change fails exactly the two MSAL cases (`ignores the MSAL sign-in popup instead of closing it`, `ignores an error response belonging to another library`) and nothing else.
- `npm run build` clean; guard confirmed present in `dist/index.html`.
- `npm run lint`: 456 problems before and after — **zero regression** (all pre-existing CRLF noise).

Not verified here: a live end-to-end Entra sign-in, which can't be run in this environment.

## Follow-up (not in this PR)

`AuthBtn.tsx:23` still lets any `signIn()` rejection reach the global ErrorBoundary, so unrelated auth failures render a full-page crash instead of an inline error. Worth hardening separately.
